### PR TITLE
Add issues and issue_comments streams

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -280,9 +280,14 @@ class IssueCommentsStream(GitHubStream):
                 params["since"] = since
         return params
 
+    def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
+        row['issue_number'] = int(row["issue_url"].split('/')[-1])
+        return row
+
     schema = th.PropertiesList(
         th.Property("id", th.IntegerType),
         th.Property("node_id", th.StringType),
+        th.Property("issue_number", th.IntegerType),
         th.Property("repo", th.StringType),
         th.Property("org", th.StringType),
         th.Property("issue_url", th.IntegerType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -130,17 +130,116 @@ class IssuesStream(GitHubStream):
 
     schema = th.PropertiesList(
         th.Property("id", th.IntegerType),
+        th.Property("node_id", th.StringType),
+        th.Property("url", th.StringType),
+        th.Property("html_url", th.StringType),
         th.Property("repo", th.StringType),
         th.Property("org", th.StringType),
-        th.Property("issue_number", th.IntegerType),
+        th.Property("number", th.IntegerType),
         th.Property("updated_at", th.DateTimeType),
         th.Property("created_at", th.DateTimeType),
-        # th.Property("closed_at", th.DateTimeType),  # Nulls causing parse error
+        th.Property("closed_at", th.DateTimeType),
         th.Property("state", th.StringType),
         th.Property("title", th.StringType),
         th.Property("comments", th.IntegerType),
         th.Property("author_association", th.StringType),
         th.Property("body", th.StringType),
+        th.Property(
+            "user",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+        th.Property(
+            "labels",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("id", th.IntegerType),
+                    th.Property("node_id", th.StringType),
+                    th.Property("url", th.StringType),
+                    th.Property("name", th.StringType),
+                    th.Property("description", th.StringType),
+                    th.Property("color", th.StringType),
+                    th.Property("default", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "assignee",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+        th.Property(
+            "assignees",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("login", th.StringType),
+                    th.Property("id", th.IntegerType),
+                    th.Property("node_id", th.StringType),
+                    th.Property("avatar_url", th.StringType),
+                    th.Property("gravatar_id", th.StringType),
+                    th.Property("html_url", th.StringType),
+                    th.Property("type", th.StringType),
+                    th.Property("site_admin", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "milestone",
+            th.ObjectType(
+                th.Property("html_url", th.StringType),
+                th.Property("node_id", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("number", th.IntegerType),
+                th.Property("state", th.StringType),
+                th.Property("title", th.StringType),
+                th.Property("description", th.StringType),
+                th.Property(
+                    "creator",
+                    th.ObjectType(
+                        th.Property("login", th.StringType),
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("avatar_url", th.StringType),
+                        th.Property("gravatar_id", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("type", th.StringType),
+                        th.Property("site_admin", th.BooleanType),
+                    ),
+                ),
+                th.Property("open_issues", th.IntegerType),
+                th.Property("closed_issues", th.IntegerType),
+                th.Property("created_at", th.DateTimeType),
+                th.Property("updated_at", th.DateTimeType),
+                th.Property("closed_at", th.DateTimeType),
+                th.Property("due_on", th.DateTimeType),
+            ),
+        ),
+        th.Property("locked", th.BooleanType),
+        th.Property(
+            "pull_request",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("html_url", th.StringType),
+                    th.Property("url", th.StringType),
+                ),
+            ),
+        ),
     ).to_dict()
 
 

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -281,7 +281,7 @@ class IssueCommentsStream(GitHubStream):
         return params
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
-        row['issue_number'] = int(row["issue_url"].split('/')[-1])
+        row["issue_number"] = int(row["issue_url"].split("/")[-1])
         return row
 
     schema = th.PropertiesList(

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -244,13 +244,17 @@ class IssuesStream(GitHubStream):
 
 
 class IssueCommentsStream(GitHubStream):
-    """Defines 'Issues' stream."""
+    """
+    Defines 'Issues' stream.
+    Issue comments are fetched from the repository level (as opposed to per issue)
+    to optimize for API quota usage.
+    """
 
     name = "issue_comments"
-    path = "/repos/{org}/{repo}/issues/{issue_number}/comments"
+    path = "/repos/{org}/{repo}/issues/comments"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    parent_stream_type = IssuesStream
+    parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
 
@@ -278,11 +282,25 @@ class IssueCommentsStream(GitHubStream):
 
     schema = th.PropertiesList(
         th.Property("id", th.IntegerType),
+        th.Property("node_id", th.StringType),
         th.Property("repo", th.StringType),
         th.Property("org", th.StringType),
-        th.Property("issue_number", th.IntegerType),
+        th.Property("issue_url", th.IntegerType),
         th.Property("updated_at", th.DateTimeType),
         th.Property("created_at", th.DateTimeType),
         th.Property("author_association", th.StringType),
         th.Property("body", th.StringType),
+        th.Property(
+            "user",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
     ).to_dict()


### PR DESCRIPTION
This PR does a couple of things:
- update the `issues` stream schema to match the docs (and actual API output) a bit more closely. I've not included *all* fields, namely excluding the "obvious" ones that can be computed trivially by appending a common postfix to the base url.
- modify the `issue_comments` stream to be a child of `repositories` as discussed in #8 and update the schema like above

Depending on how quickly this gets merged, I might add `issue_events` here, or in a separate PR, following the same logic.