### PR TITLE
Add commits stream

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -375,3 +375,113 @@ class IssueCommentsStream(GitHubStream):
             ),
         ),
     ).to_dict()
+
+
+class CommitsStream(GitHubStream):
+    """
+    Defines the 'Commits' stream.
+    The stream is fetched per repository to maximize optimize for API quota
+    usage.
+    """
+
+    name = "commits"
+    path = "/repos/{org}/{repo}/commits"
+    primary_keys = ["node_id"]
+    replication_key = "commit_timestamp"
+    parent_stream_type = RepositoryStream
+    state_partitioning_keys = ["repo", "org"]
+    ignore_parent_replication_key = True
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params = super().get_url_params(context, next_page_token)
+        if self.replication_key:
+            since = self.get_starting_timestamp(context)
+            if since:
+                params["since"] = since
+        return params
+
+    def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
+        """
+        Add a timestamp top-level field to be used as state replication key.
+        It's not clear from github's API docs which time (author or committer)
+        is used to compare to the `since` argument that the endpoint supports.
+        """
+        row["commit_timestamp"] = row["commit"]["committer"]["date"]
+        return row
+
+    schema = th.PropertiesList(
+        th.Property("node_id", th.IntegerType),
+        th.Property("url", th.StringType),
+        th.Property("sha", th.StringType),
+        th.Property("html_url", th.StringType),
+        th.Property("commit_timestamp", th.DateTimeType),
+        th.Property(
+            "commit",
+            th.ObjectType(
+                th.Property(
+                    "author",
+                    th.ObjectType(
+                        th.Property("name", th.StringType),
+                        th.Property("email", th.StringType),
+                        th.Property("date", th.DateTimeType),
+                    ),
+                ),
+                th.Property(
+                    "committer",
+                    th.ObjectType(
+                        th.Property("name", th.StringType),
+                        th.Property("email", th.StringType),
+                        th.Property("date", th.DateTimeType),
+                    ),
+                ),
+                th.Property("message", th.StringType),
+                th.Property(
+                    "tree",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("sha", th.StringType),
+                    ),
+                ),
+                th.Property("comment_count", th.IntegerType),
+                th.Property(
+                    "verification",
+                    th.ObjectType(
+                        th.Property("verified", th.BooleanType),
+                        th.Property("reason", th.StringType),
+                        th.Property("signature", th.StringType),
+                        th.Property("payload", th.StringType),
+                    ),
+                ),
+            ),
+        ),
+        th.Property(
+            "author",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+        th.Property(
+            "committer",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+    ).to_dict()
+

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -460,7 +460,6 @@ class CommitsStream(GitHubStream):
                         th.Property("sha", th.StringType),
                     ),
                 ),
-                th.Property("comment_count", th.IntegerType),
                 th.Property(
                     "verification",
                     th.ObjectType(

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -335,17 +335,6 @@ class IssueCommentsStream(GitHubStream):
 
         return super().get_records(context)
 
-    def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Dict[str, Any]:
-        """Return a dictionary of values to be used in URL parameterization."""
-        params = super().get_url_params(context, next_page_token)
-        if self.replication_key:
-            since = self.get_starting_timestamp(context)
-            if since:
-                params["since"] = since
-        return params
-
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
         row["issue_number"] = int(row["issue_url"].split("/")[-1])
         return row
@@ -391,17 +380,6 @@ class CommitsStream(GitHubStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = True
-
-    def get_url_params(
-        self, context: Optional[dict], next_page_token: Optional[Any]
-    ) -> Dict[str, Any]:
-        """Return a dictionary of values to be used in URL parameterization."""
-        params = super().get_url_params(context, next_page_token)
-        if self.replication_key:
-            since = self.get_starting_timestamp(context)
-            if since:
-                params["since"] = since
-        return params
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
         """

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -484,4 +484,3 @@ class CommitsStream(GitHubStream):
             ),
         ),
     ).to_dict()
-

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -413,7 +413,7 @@ class CommitsStream(GitHubStream):
         return row
 
     schema = th.PropertiesList(
-        th.Property("node_id", th.IntegerType),
+        th.Property("node_id", th.StringType),
         th.Property("url", th.StringType),
         th.Property("sha", th.StringType),
         th.Property("html_url", th.StringType),

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -5,7 +5,12 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream
+from tap_github.streams import (
+    CommitsStream,
+    IssueCommentsStream,
+    IssuesStream,
+    RepositoryStream,
+)
 
 
 class TapGitHub(Tap):
@@ -35,9 +40,10 @@ class TapGitHub(Tap):
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
         return [
-            RepositoryStream(tap=self),
-            IssuesStream(tap=self),
+            CommitsStream(tap=self),
             IssueCommentsStream(tap=self),
+            IssuesStream(tap=self),
+            RepositoryStream(tap=self),
         ]
 
 


### PR DESCRIPTION
This PR adds another stream to the tap, for commits.
I improvised a bit for the replication key, as the API does not provide a top-level timestamp field, and couldn't figure out a way to use a nested one.

There is no testing either, but I've run the tap against `target-postgres` and the data appears as expected, which is better than nothing :)