### PR TITLE
Add CommunityProfile stream and enhance error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# IDE
+.idea/
+
 # Pyre type checker
 .pyre/
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -89,7 +89,9 @@ class GitHubStream(RESTStream):
                 extra_tags=extra_tags,
             )
         if response.status_code in self.tolerated_http_errors:
-            self.logger.info("Request returned a tolerated error for {}".format(prepared_request.url))
+            self.logger.info(
+                "Request returned a tolerated error for {}".format(prepared_request.url)
+            )
             self.logger.info(
                 f"Reason: {response.status_code} - {str(response.content)}"
             )

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -20,6 +20,7 @@ class GitHubStream(RESTStream):
 
     primary_keys = ["id"]
     replication_key: Optional[str] = None
+    tolerated_http_errors = []
 
     @property
     def http_headers(self) -> dict:
@@ -71,13 +72,61 @@ class GitHubStream(RESTStream):
                 params["since"] = since
         return params
 
+    def _request_with_backoff(
+        self, prepared_request, context: Optional[dict]
+    ) -> requests.Response:
+        """Override private method _request_with_backoff to account for expected 404 Not Found erros."""
+        # TODO - Adapt Singer
+        response = self.requests_session.send(prepared_request)
+        if self._LOG_REQUEST_METRICS:
+            extra_tags = {}
+            if self._LOG_REQUEST_METRIC_URLS:
+                extra_tags["url"] = cast(str, prepared_request.path_url)
+            self._write_request_duration_log(
+                endpoint=self.path,
+                response=response,
+                context=context,
+                extra_tags=extra_tags,
+            )
+        if response.status_code in self.tolerated_http_errors:
+            self.logger.info("Request returned a tolerated error for {}".format(prepared_request.url))
+            self.logger.info(
+                f"Reason: {response.status_code} - {str(response.content)}"
+            )
+            return response
+
+        if response.status_code in [401, 403]:
+            self.logger.info("Failed request for {}".format(prepared_request.url))
+            self.logger.info(
+                f"Reason: {response.status_code} - {str(response.content)}"
+            )
+            raise RuntimeError(
+                "Requested resource was unauthorized, forbidden, or not found."
+            )
+        elif response.status_code >= 400:
+            raise RuntimeError(
+                f"Error making request to API: {prepared_request.url} "
+                f"[{response.status_code} - {str(response.content)}]".replace(
+                    "\\n", "\n"
+                )
+            )
+        self.logger.debug("Response received successfully.")
+        return response
+
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response and return an iterator of result rows."""
+        # TODO - Split into handle_reponse and parse_response.
+        if response.status_code in self.tolerated_http_errors:
+            return []
+
         resp_json = response.json()
+
         if isinstance(resp_json, list):
             results = resp_json
-        else:
+        elif resp_json.get("items") is not None:
             results = resp_json.get("items")
+        else:
+            results = [resp_json]
 
         for row in results:
             yield row

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -1,7 +1,7 @@
 """REST client handling, including GitHubStream base class."""
 
 import requests
-from typing import Any, Dict, Optional, Iterable, cast
+from typing import Any, Dict, List, Optional, Iterable, cast
 
 from singer_sdk.streams import RESTStream
 
@@ -20,7 +20,7 @@ class GitHubStream(RESTStream):
 
     primary_keys = ["id"]
     replication_key: Optional[str] = None
-    tolerated_http_errors = []
+    tolerated_http_errors: List[int] = []
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -161,7 +161,6 @@ class ReadmeStream(GitHubStream):
     name = "readme"
     path = "/repos/{org}/{repo}/readme"
     primary_keys = ["url"]
-    # TODO what would this be? replication_key = "updated_at"
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -2,8 +2,6 @@
 
 import requests
 from typing import Any, Dict, Iterable, List, Optional
-
-import requests
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_github.client import GitHubStream
@@ -169,8 +167,7 @@ class ReadmeStream(GitHubStream):
     state_partitioning_keys = ["repo", "org"]
 
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        json = response.json()
-        yield json
+        return [response.json()]
 
     schema = th.PropertiesList(
         th.Property("type", th.StringType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -195,6 +195,92 @@ class ReadmeStream(GitHubStream):
     ).to_dict()
 
 
+class CommunityProfileStream(GitHubStream):
+    """Defines 'CommunityProfile' stream."""
+
+    name = "community_profile"
+    path = "/repos/{org}/{repo}/community/profile"
+    primary_keys = ["repo", "org"]
+    parent_stream_type = RepositoryStream
+    ignore_parent_replication_key = False
+    state_partitioning_keys = ["repo", "org"]
+
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+        return [response.json()]
+
+    schema = th.PropertiesList(
+        # Parent Keys
+        th.Property("repo", th.StringType),
+        th.Property("org", th.StringType),
+        # Community Profile
+        th.Property("health_percentage", th.IntegerType),
+        th.Property("description", th.StringType),
+        th.Property("documentation", th.StringType),
+        th.Property("updated_at", th.DateTimeType),
+        th.Property("content_reports_enabled", th.BooleanType),
+        th.Property(
+            "files",
+            th.ObjectType(
+                th.Property(
+                    "code_of_conduct",
+                    th.ObjectType(
+                        th.Property("key", th.StringType),
+                        th.Property("name", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "code_of_conduct_file",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "contributing",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "issue_template",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "pull_request_template",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "license",
+                    th.ObjectType(
+                        th.Property("key", th.StringType),
+                        th.Property("name", th.StringType),
+                        th.Property("spdx_id", th.StringType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("url", th.StringType),
+                    )
+                ),
+                th.Property(
+                    "readme",
+                    th.ObjectType(
+                        th.Property("url", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    )
+                ),
+            ),
+        ),
+    ).to_dict()
+
+
 class IssuesStream(GitHubStream):
     """Defines 'Issues' stream."""
 

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -213,35 +213,35 @@ class CommunityProfileStream(GitHubStream):
                         th.Property("name", th.StringType),
                         th.Property("html_url", th.StringType),
                         th.Property("url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "code_of_conduct_file",
                     th.ObjectType(
                         th.Property("url", th.StringType),
                         th.Property("html_url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "contributing",
                     th.ObjectType(
                         th.Property("url", th.StringType),
                         th.Property("html_url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "issue_template",
                     th.ObjectType(
                         th.Property("url", th.StringType),
                         th.Property("html_url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "pull_request_template",
                     th.ObjectType(
                         th.Property("url", th.StringType),
                         th.Property("html_url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "license",
@@ -252,14 +252,14 @@ class CommunityProfileStream(GitHubStream):
                         th.Property("node_id", th.StringType),
                         th.Property("html_url", th.StringType),
                         th.Property("url", th.StringType),
-                    )
+                    ),
                 ),
                 th.Property(
                     "readme",
                     th.ObjectType(
                         th.Property("url", th.StringType),
                         th.Property("html_url", th.StringType),
-                    )
+                    ),
                 ),
             ),
         ),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -57,15 +57,6 @@ class RepositoryStream(GitHubStream):
             return [{"org": r[0], "repo": r[1]} for r in split_repo_names]
         return None
 
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        """
-        Parse the response which differs for this stream depending on which mode it is run in.
-        """
-        if "searches" in self.config:
-            return super(GitHubStream, self).parse_response(response)
-        else:
-            return [response.json()]
-
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a child context object from the record and optional provided context.
 
@@ -165,9 +156,6 @@ class ReadmeStream(GitHubStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
 
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        return [response.json()]
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -204,9 +192,7 @@ class CommunityProfileStream(GitHubStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
-
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
-        return [response.json()]
+    tolerated_http_errors = [404]
 
     schema = th.PropertiesList(
         # Parent Keys

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -186,7 +186,7 @@ class ReadmeStream(GitHubStream):
         th.Property("download_url", th.StringType),
         th.Property(
             "_links",
-            th.PropertiesList(
+            th.ObjectType(
                 th.Property("git", th.StringType),
                 th.Property("self", th.StringType),
                 th.Property("html", th.StringType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -18,7 +18,7 @@ class RepositoryStream(GitHubStream):
     name = "repositories"
 
     def get_url_params(
-            self, context: Optional[dict], next_page_token: Optional[Any]
+        self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         assert context is not None, f"Context cannot be empty for '{self.name}' stream."
@@ -118,11 +118,14 @@ class ReadmeStream(GitHubStream):
         th.Property("git_url", th.StringType),
         th.Property("html_url", th.StringType),
         th.Property("download_url", th.StringType),
-        th.Property("_links", th.PropertiesList(
-            th.Property("git", th.StringType),
-            th.Property("self", th.StringType),
-            th.Property("html", th.StringType),
-        )),
+        th.Property(
+            "_links",
+            th.PropertiesList(
+                th.Property("git", th.StringType),
+                th.Property("self", th.StringType),
+                th.Property("html", th.StringType),
+            ),
+        ),
     ).to_dict()
 
 
@@ -201,7 +204,7 @@ class IssueCommentsStream(GitHubStream):
         return super().get_records(context)
 
     def get_url_params(
-            self, context: Optional[dict], next_page_token: Optional[Any]
+        self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params = super().get_url_params(context, next_page_token)

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -160,7 +160,7 @@ class RepositoryStream(GitHubStream):
 class ReadmeStream(GitHubStream):
     name = "readme"
     path = "/repos/{org}/{repo}/readme"
-    primary_keys = ["url"]
+    primary_keys = ["repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
@@ -169,6 +169,10 @@ class ReadmeStream(GitHubStream):
         return [response.json()]
 
     schema = th.PropertiesList(
+        # Parent Keys
+        th.Property("repo", th.StringType),
+        th.Property("org", th.StringType),
+        # README Keys
         th.Property("type", th.StringType),
         th.Property("encoding", th.StringType),
         th.Property("size", th.IntegerType),

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -10,6 +10,7 @@ from tap_github.streams import (
     IssuesStream,
     IssueCommentsStream,
     ReadmeStream,
+    CommunityProfileStream,
 )
 
 
@@ -44,6 +45,7 @@ class TapGitHub(Tap):
             IssuesStream(tap=self),
             IssueCommentsStream(tap=self),
             ReadmeStream(tap=self),
+            CommunityProfileStream(tap=self),
         ]
 
 

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -5,7 +5,12 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream, ReadmeStream
+from tap_github.streams import (
+    RepositoryStream,
+    IssuesStream,
+    IssueCommentsStream,
+    ReadmeStream,
+)
 
 
 class TapGitHub(Tap):

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -5,7 +5,7 @@ from typing import List
 from singer_sdk import Tap, Stream
 from singer_sdk import typing as th  # JSON schema typing helpers
 
-from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream
+from tap_github.streams import RepositoryStream, IssuesStream, IssueCommentsStream, ReadmeStream
 
 
 class TapGitHub(Tap):
@@ -38,6 +38,7 @@ class TapGitHub(Tap):
             RepositoryStream(tap=self),
             IssuesStream(tap=self),
             IssueCommentsStream(tap=self),
+            ReadmeStream(tap=self),
         ]
 
 


### PR DESCRIPTION
Adding a stream for CommunityProfile.

Enhancing error handling because fetching `community/profile` from the GitHub API sometimes return a `404 - Not Found`. See #16 for more details.