### PR TITLE
Add PullRequests stream and get all issues and prs regardless of state

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -256,6 +256,7 @@ class IssuesStream(GitHubStream):
         th.Property("comments", th.IntegerType),
         th.Property("author_association", th.StringType),
         th.Property("body", th.StringType),
+        th.Property("type", th.StringType),
         th.Property(
             "user",
             th.ObjectType(

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -237,7 +237,7 @@ class IssuesStream(GitHubStream):
         return headers
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
-        row["type"] = "pull_request" if row["pull_request"] else "issue"
+        row["type"] = "pull_request" if "pull_request" in row else "issue"
         return row
 
     schema = th.PropertiesList(

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -271,6 +271,23 @@ class IssuesStream(GitHubStream):
             ),
         ),
         th.Property(
+            "reactions",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("url", th.StringType),
+                    th.Property("total_count", th.IntegerType),
+                    th.Property("+1", th.IntegerType),
+                    th.Property("-1", th.IntegerType),
+                    th.Property("laugh", th.IntegerType),
+                    th.Property("hooray", th.IntegerType),
+                    th.Property("confused", th.IntegerType),
+                    th.Property("heart", th.IntegerType),
+                    th.Property("rocket", th.IntegerType),
+                    th.Property("eyes", th.IntegerType),
+                ),
+            ),
+        ),
+        th.Property(
             "assignee",
             th.ObjectType(
                 th.Property("login", th.StringType),
@@ -431,20 +448,6 @@ class PullRequestsStream(GitHubStream):
         params["state"] = "all"
         return params
 
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a child context object from the record and optional provided context.
-
-        By default, will return context if provided and otherwise the record dict.
-        Developers may override this behavior to send specific information to child
-        streams for context.
-        """
-        if context is None:
-            raise ValueError("Issue stream should not have blank context.")
-
-        context["issue_number"] = record["number"]
-        context["comments"] = record["comments"]  # If zero, comments can be skipped
-        return context
-
     @property
     def http_headers(self) -> dict:
         """Return the http headers needed.
@@ -509,6 +512,23 @@ class PullRequestsStream(GitHubStream):
                     th.Property("description", th.StringType),
                     th.Property("color", th.StringType),
                     th.Property("default", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "reactions",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("url", th.StringType),
+                    th.Property("total_count", th.IntegerType),
+                    th.Property("+1", th.IntegerType),
+                    th.Property("-1", th.IntegerType),
+                    th.Property("laugh", th.IntegerType),
+                    th.Property("hooray", th.IntegerType),
+                    th.Property("confused", th.IntegerType),
+                    th.Property("heart", th.IntegerType),
+                    th.Property("rocket", th.IntegerType),
+                    th.Property("eyes", th.IntegerType),
                 ),
             ),
         ),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -237,7 +237,7 @@ class IssuesStream(GitHubStream):
         return headers
 
     def post_process(self, row: dict, context: Optional[dict] = None) -> dict:
-        row["type"] = 'pull_request' if row["pull_request"] else 'issue'
+        row["type"] = "pull_request" if row["pull_request"] else "issue"
         return row
 
     schema = th.PropertiesList(

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -206,6 +206,17 @@ class IssuesStream(GitHubStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
 
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        assert context is not None, f"Context cannot be empty for '{self.name}' stream."
+        params = super().get_url_params(context, next_page_token)
+        # Fetch all issues, regardless of state (OPEN, CLOSED, MERGED) but not prs.
+        params["state"] = "all"
+        params["pulls"] = "false"
+        return params
+
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a child context object from the record and optional provided context.
 
@@ -409,6 +420,257 @@ class IssueCommentsStream(GitHubStream):
                 th.Property("html_url", th.StringType),
                 th.Property("type", th.StringType),
                 th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+    ).to_dict()
+
+
+class PullRequestsStream(GitHubStream):
+    """Defines 'PullRequests' stream."""
+
+    name = "pull_requests"
+    path = "/repos/{org}/{repo}/pulls"
+    primary_keys = ["id"]
+    replication_key = "updated_at"
+    parent_stream_type = RepositoryStream
+    ignore_parent_replication_key = False
+    state_partitioning_keys = ["repo", "org"]
+
+    def get_url_params(
+        self, context: Optional[dict], next_page_token: Optional[Any]
+    ) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        assert context is not None, f"Context cannot be empty for '{self.name}' stream."
+        params = super().get_url_params(context, next_page_token)
+        # Fetch all pull requests regardless of state (OPEN, CLOSED, MERGED).
+        params["state"] = "all"
+        return params
+
+    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
+        """Return a child context object from the record and optional provided context.
+
+        By default, will return context if provided and otherwise the record dict.
+        Developers may override this behavior to send specific information to child
+        streams for context.
+        """
+        if context is None:
+            raise ValueError("Issue stream should not have blank context.")
+
+        context["issue_number"] = record["number"]
+        context["comments"] = record["comments"]  # If zero, comments can be skipped
+        return context
+
+    @property
+    def http_headers(self) -> dict:
+        """Return the http headers needed.
+
+        Overridden to use beta endpoint which includes reactions as described here:
+        https://developer.github.com/changes/2016-05-12-reactions-api-preview/
+        """
+        headers = super().http_headers
+        headers["Accept"] = "application/vnd.github.squirrel-girl-preview"
+        return headers
+
+    schema = th.PropertiesList(
+        # Parent keys
+        th.Property("repo", th.StringType),
+        th.Property("org", th.StringType),
+        # PR keys
+        th.Property("id", th.IntegerType),
+        th.Property("node_id", th.StringType),
+        th.Property("url", th.StringType),
+        th.Property("html_url", th.StringType),
+        th.Property("diff_url", th.StringType),
+        th.Property("patch_url", th.StringType),
+        th.Property("number", th.IntegerType),
+        th.Property("updated_at", th.DateTimeType),
+        th.Property("created_at", th.DateTimeType),
+        th.Property("closed_at", th.DateTimeType),
+        th.Property("merged_at", th.DateTimeType),
+        th.Property("state", th.StringType),
+        th.Property("title", th.StringType),
+        th.Property("locked", th.BooleanType),
+        th.Property("comments", th.IntegerType),
+        th.Property("author_association", th.StringType),
+        th.Property("body", th.StringType),
+        th.Property("merge_commit_sha", th.StringType),
+        th.Property("draft", th.BooleanType),
+        th.Property("commits_url", th.StringType),
+        th.Property("review_comments_url", th.StringType),
+        th.Property("review_comment_url", th.StringType),
+        th.Property("comments_url", th.StringType),
+        th.Property("statuses_url", th.StringType),
+        th.Property(
+            "user",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+        th.Property(
+            "labels",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("id", th.IntegerType),
+                    th.Property("node_id", th.StringType),
+                    th.Property("url", th.StringType),
+                    th.Property("name", th.StringType),
+                    th.Property("description", th.StringType),
+                    th.Property("color", th.StringType),
+                    th.Property("default", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "assignee",
+            th.ObjectType(
+                th.Property("login", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("node_id", th.StringType),
+                th.Property("avatar_url", th.StringType),
+                th.Property("gravatar_id", th.StringType),
+                th.Property("html_url", th.StringType),
+                th.Property("type", th.StringType),
+                th.Property("site_admin", th.BooleanType),
+            ),
+        ),
+        th.Property(
+            "assignees",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("login", th.StringType),
+                    th.Property("id", th.IntegerType),
+                    th.Property("node_id", th.StringType),
+                    th.Property("avatar_url", th.StringType),
+                    th.Property("gravatar_id", th.StringType),
+                    th.Property("html_url", th.StringType),
+                    th.Property("type", th.StringType),
+                    th.Property("site_admin", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "requested_reviewers",
+            th.ArrayType(
+                th.ObjectType(
+                    th.Property("login", th.StringType),
+                    th.Property("id", th.IntegerType),
+                    th.Property("node_id", th.StringType),
+                    th.Property("avatar_url", th.StringType),
+                    th.Property("gravatar_id", th.StringType),
+                    th.Property("html_url", th.StringType),
+                    th.Property("type", th.StringType),
+                    th.Property("site_admin", th.BooleanType),
+                ),
+            ),
+        ),
+        th.Property(
+            "milestone",
+            th.ObjectType(
+                th.Property("html_url", th.StringType),
+                th.Property("node_id", th.StringType),
+                th.Property("id", th.IntegerType),
+                th.Property("number", th.IntegerType),
+                th.Property("state", th.StringType),
+                th.Property("title", th.StringType),
+                th.Property("description", th.StringType),
+                th.Property(
+                    "creator",
+                    th.ObjectType(
+                        th.Property("login", th.StringType),
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("avatar_url", th.StringType),
+                        th.Property("gravatar_id", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("type", th.StringType),
+                        th.Property("site_admin", th.BooleanType),
+                    ),
+                ),
+                th.Property("open_issues", th.IntegerType),
+                th.Property("closed_issues", th.IntegerType),
+                th.Property("created_at", th.DateTimeType),
+                th.Property("updated_at", th.DateTimeType),
+                th.Property("closed_at", th.DateTimeType),
+                th.Property("due_on", th.DateTimeType),
+            ),
+        ),
+        th.Property("locked", th.BooleanType),
+        th.Property(
+            "pull_request",
+            th.ObjectType(
+                th.Property("html_url", th.StringType),
+                th.Property("url", th.StringType),
+                th.Property("diff_url", th.StringType),
+                th.Property("patch_url", th.StringType),
+            ),
+        ),
+        th.Property(
+            "head",
+            th.ObjectType(
+                th.Property("label", th.StringType),
+                th.Property("ref", th.StringType),
+                th.Property("sha", th.StringType),
+                th.Property(
+                    "user",
+                    th.ObjectType(
+                        th.Property("login", th.StringType),
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("avatar_url", th.StringType),
+                        th.Property("gravatar_id", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("type", th.StringType),
+                        th.Property("site_admin", th.BooleanType),
+                    ),
+                ),
+                th.Property(
+                    "repo",
+                    th.ObjectType(
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("name", th.StringType),
+                        th.Property("full_name", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    ),
+                ),
+            ),
+        ),
+        th.Property(
+            "base",
+            th.ObjectType(
+                th.Property("label", th.StringType),
+                th.Property("ref", th.StringType),
+                th.Property("sha", th.StringType),
+                th.Property(
+                    "user",
+                    th.ObjectType(
+                        th.Property("login", th.StringType),
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("avatar_url", th.StringType),
+                        th.Property("gravatar_id", th.StringType),
+                        th.Property("html_url", th.StringType),
+                        th.Property("type", th.StringType),
+                        th.Property("site_admin", th.BooleanType),
+                    ),
+                ),
+                th.Property(
+                    "repo",
+                    th.ObjectType(
+                        th.Property("id", th.IntegerType),
+                        th.Property("node_id", th.StringType),
+                        th.Property("name", th.StringType),
+                        th.Property("full_name", th.StringType),
+                        th.Property("html_url", th.StringType),
+                    ),
+                ),
             ),
         ),
     ).to_dict()

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -212,24 +212,9 @@ class IssuesStream(GitHubStream):
         """Return a dictionary of values to be used in URL parameterization."""
         assert context is not None, f"Context cannot be empty for '{self.name}' stream."
         params = super().get_url_params(context, next_page_token)
-        # Fetch all issues, regardless of state (OPEN, CLOSED, MERGED) but not prs.
+        # Fetch all issues and PRs, regardless of state (OPEN, CLOSED, MERGED).
         params["state"] = "all"
-        params["pulls"] = "false"
         return params
-
-    def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
-        """Return a child context object from the record and optional provided context.
-
-        By default, will return context if provided and otherwise the record dict.
-        Developers may override this behavior to send specific information to child
-        streams for context.
-        """
-        if context is None:
-            raise ValueError("Issue stream should not have blank context.")
-
-        context["issue_number"] = record["number"]
-        context["comments"] = record["comments"]  # If zero, comments can be skipped
-        return context
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -9,6 +9,7 @@ from tap_github.streams import (
     RepositoryStream,
     IssuesStream,
     IssueCommentsStream,
+    PullRequestsStream,
     ReadmeStream,
 )
 
@@ -43,6 +44,7 @@ class TapGitHub(Tap):
             RepositoryStream(tap=self),
             IssuesStream(tap=self),
             IssueCommentsStream(tap=self),
+            PullRequestsStream(tap=self),
             ReadmeStream(tap=self),
         ]
 


### PR DESCRIPTION
Following up on #17, I would like to propose this solution.

This PR:
- creates a new PullRequests stream that fetches PRs only (regardless of state).
- updates the Issue stream to fetch all issues (and PRs) regardless of state and add a "type" field