### PR TITLE
Fix reactions mapping type in Issues and PRs streams

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -357,19 +357,17 @@ class IssuesStream(GitHubStream):
         ),
         th.Property(
             "reactions",
-            th.ArrayType(
-                th.ObjectType(
-                    th.Property("url", th.StringType),
-                    th.Property("total_count", th.IntegerType),
-                    th.Property("+1", th.IntegerType),
-                    th.Property("-1", th.IntegerType),
-                    th.Property("laugh", th.IntegerType),
-                    th.Property("hooray", th.IntegerType),
-                    th.Property("confused", th.IntegerType),
-                    th.Property("heart", th.IntegerType),
-                    th.Property("rocket", th.IntegerType),
-                    th.Property("eyes", th.IntegerType),
-                ),
+            th.ObjectType(
+                th.Property("url", th.StringType),
+                th.Property("total_count", th.IntegerType),
+                th.Property("+1", th.IntegerType),
+                th.Property("-1", th.IntegerType),
+                th.Property("laugh", th.IntegerType),
+                th.Property("hooray", th.IntegerType),
+                th.Property("confused", th.IntegerType),
+                th.Property("heart", th.IntegerType),
+                th.Property("rocket", th.IntegerType),
+                th.Property("eyes", th.IntegerType),
             ),
         ),
         th.Property(
@@ -746,19 +744,17 @@ class PullRequestsStream(GitHubStream):
         ),
         th.Property(
             "reactions",
-            th.ArrayType(
-                th.ObjectType(
-                    th.Property("url", th.StringType),
-                    th.Property("total_count", th.IntegerType),
-                    th.Property("+1", th.IntegerType),
-                    th.Property("-1", th.IntegerType),
-                    th.Property("laugh", th.IntegerType),
-                    th.Property("hooray", th.IntegerType),
-                    th.Property("confused", th.IntegerType),
-                    th.Property("heart", th.IntegerType),
-                    th.Property("rocket", th.IntegerType),
-                    th.Property("eyes", th.IntegerType),
-                ),
+            th.ObjectType(
+                th.Property("url", th.StringType),
+                th.Property("total_count", th.IntegerType),
+                th.Property("+1", th.IntegerType),
+                th.Property("-1", th.IntegerType),
+                th.Property("laugh", th.IntegerType),
+                th.Property("hooray", th.IntegerType),
+                th.Property("confused", th.IntegerType),
+                th.Property("heart", th.IntegerType),
+                th.Property("rocket", th.IntegerType),
+                th.Property("eyes", th.IntegerType),
             ),
         ),
         th.Property(

--- a/tap_github/tests/fixtures.py
+++ b/tap_github/tests/fixtures.py
@@ -23,7 +23,7 @@ def repo_list_config(request):
     """
     marker = request.node.get_closest_marker("repo_list")
     if marker is None:
-        repo_list = ["octocat/hello-world"]
+        repo_list = ["octocat/hello-world", "mapswipe/mapswipe"]
     else:
         repo_list = marker.args[0]
 

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -45,4 +45,6 @@ def test_get_a_repository_in_repo_list_mode(capsys, repo_list_config):
     tap2.sync_all()
     captured = capsys.readouterr()
     # Verify we got the right number of records (one per repo in the list)
-    assert captured.out.count('{"type": "RECORD", "stream": "repositories"') == len(repo_list_2)
+    assert captured.out.count('{"type": "RECORD", "stream": "repositories"') == len(
+        repo_list_2
+    )

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -9,7 +9,7 @@ from singer_sdk.helpers._catalog import (
 
 from .fixtures import repo_list_config
 
-repo_list_2 = ["octocat/hello-world", "MeltanoLabs/tap-github"]
+repo_list_2 = ["octocat/hello-world", "MeltanoLabs/tap-github", "mapswipe/mapswipe"]
 
 
 @pytest.mark.repo_list(repo_list_2)
@@ -18,6 +18,7 @@ def test_validate_repo_list_config(repo_list_config):
     repo_list_context = [
         {"org": "octocat", "repo": "hello-world"},
         {"org": "MeltanoLabs", "repo": "tap-github"},
+        {"org": "mapswipe", "repo": "mapswipe"},
     ]
     tap = TapGitHub(config=repo_list_config)
     partitions = tap.streams["repositories"].partitions
@@ -44,4 +45,4 @@ def test_get_a_repository_in_repo_list_mode(capsys, repo_list_config):
     tap2.sync_all()
     captured = capsys.readouterr()
     # Verify we got the right number of records (one per repo in the list)
-    assert captured.out.count('{"type": "RECORD", "stream": "repositories"') == 2
+    assert captured.out.count('{"type": "RECORD", "stream": "repositories"') == len(repo_list_2)


### PR DESCRIPTION
Quick fix for reactions mapping. As a side question, now that we use the GitHub token, what do you think of adding more projects to tests @aaronsteers? We could propose https://github.com/mapswipe/mapswipe which @laurentS and I work on and has varied inputs.