### PR TITLE
Support python 3.10 in CI

### DIFF
--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -10,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3,10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -10,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -10,7 +10,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3,10"]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The quotes are needed to prevent github from reading it as `3.1`.
