### PR TITLE
Adjust max-per-page constant to match api docs

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -10,7 +10,7 @@ from singer_sdk.streams import RESTStream
 class GitHubStream(RESTStream):
     """GitHub stream class."""
 
-    MAX_PER_PAGE = 1000
+    MAX_PER_PAGE = 100
     MAX_RESULTS_LIMIT: Optional[int] = None
     DEFAULT_API_BASE_URL = "https://api.github.com"
     LOG_REQUEST_METRIC_URLS = True


### PR DESCRIPTION
Trivial PR to correct a typo in the code.
A quick review of github API docs (eg [here](https://docs.github.com/en/rest/reference/repos#list-organization-repositories)) says that the max is 100, not 1k.