### PR TITLE
Tolerate 502 errors from github on issue comments

### DIFF
--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -504,6 +504,9 @@ class IssueCommentsStream(GitHubStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
+    # FIXME: this allows the tap to continue on server-side timeouts but means
+    # we have gaps in our data
+    tolerated_http_errors = [502]
 
     def get_records(self, context: Optional[dict] = None) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.


### PR DESCRIPTION
This is a temporary patch for #52 but does not fix the core issue in a satisfactory manner.

This allows the tap to keep running, which is a better outcome than a plain crash :man_shrugging: 