### PR TITLE
Use literal reaction names [breaking]

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -569,6 +569,10 @@ class IssuesStream(GitHubStream):
             # such chars are removed from the data before we pass it on to
             # the target
             row["body"] = row["body"].replace("\x00", "")
+
+        # replace +1/-1 emojis to avoid downstream column name errors.
+        row["plus_one"] = row.pop("+1", None)
+        row["minus_one"] = row.pop("-1", None)
         return row
 
     schema = th.PropertiesList(
@@ -962,6 +966,10 @@ class PullRequestsStream(GitHubStream):
             # such chars are removed from the data before we pass it on to
             # the target
             row["body"] = row["body"].replace("\x00", "")
+
+        # replace +1/-1 emojis to avoid downstream column name errors.
+        row["plus_one"] = row.pop("+1", None)
+        row["minus_one"] = row.pop("-1", None)
         return row
 
     schema = th.PropertiesList(
@@ -1340,7 +1348,9 @@ class StatsContributorsStream(GitHubStream):
                 # no need to save weeks with no contributions.
                 if sum(week[key] for key in ["a", "c", "d"]) == 0:
                     continue
-                week_with_author = {replacement_keys[k]: v for k, v in week.items()}
+                week_with_author = {
+                    replacement_keys.get(k, k): v for k, v in week.items()
+                }
                 week_with_author.update(contributor_activity["author"])
                 week_with_author["user_id"] = week_with_author.pop("id")
                 yield week_with_author

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -620,8 +620,8 @@ class IssuesStream(GitHubStream):
             th.ObjectType(
                 th.Property("url", th.StringType),
                 th.Property("total_count", th.IntegerType),
-                th.Property("+1", th.IntegerType),
-                th.Property("-1", th.IntegerType),
+                th.Property("plus_one", th.IntegerType),
+                th.Property("minus_one", th.IntegerType),
                 th.Property("laugh", th.IntegerType),
                 th.Property("hooray", th.IntegerType),
                 th.Property("confused", th.IntegerType),
@@ -1025,8 +1025,8 @@ class PullRequestsStream(GitHubStream):
             th.ObjectType(
                 th.Property("url", th.StringType),
                 th.Property("total_count", th.IntegerType),
-                th.Property("+1", th.IntegerType),
-                th.Property("-1", th.IntegerType),
+                th.Property("plus_one", th.IntegerType),
+                th.Property("minus_one", th.IntegerType),
                 th.Property("laugh", th.IntegerType),
                 th.Property("hooray", th.IntegerType),
                 th.Property("confused", th.IntegerType),


### PR DESCRIPTION
Following on @laurentS option to fix #64 by using a literal version of reaction emojis +1/-1 to plus_one/minus_one