### PR TITLE
Change order of columns in pkey indexes to improve db performance

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1197,7 +1197,7 @@ class ContributorsStream(GitHubStream):
 
     name = "contributors"
     path = "/repos/{org}/{repo}/contributors"
-    primary_keys = ["org", "repo", "node_id"]
+    primary_keys = ["node_id", "repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
@@ -1234,7 +1234,7 @@ class AnonymousContributorsStream(GitHubStream):
 
     name = "anonymous_contributors"
     path = "/repos/{org}/{repo}/contributors"
-    primary_keys = ["org", "repo", "email"]
+    primary_keys = ["email", "repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
@@ -1271,7 +1271,7 @@ class StargazersStream(GitHubStream):
 
     name = "stargazers"
     path = "/repos/{org}/{repo}/stargazers"
-    primary_keys = ["repo", "org", "user_id"]
+    primary_keys = ["user_id", "repo", "org"]
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     replication_key = "starred_at"
@@ -1325,7 +1325,7 @@ class StatsContributorsStream(GitHubStream):
 
     name = "stats_contributors"
     path = "/repos/{org}/{repo}/stats/contributors"
-    primary_keys = ["org", "repo", "user_id", "week_start"]
+    primary_keys = ["user_id", "week_start", "repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]


### PR DESCRIPTION
We've had a database review for performance bottlenecks by a postgresql expert, and one of the recommendations was to swap the order of index columns in the indexes created on the tables that come out of this tap + `target-postgres`.

The commit in this PR shows how the columns were reordered, allowing for faster updates. The gist of it is that the columns with highest cardinality (most distinct values) should come first, followed by lower cardinality.

This change seems to have helped on our setup.

2 caveats:
- the exact order might vary somewhat depending on what data is being fetched. The order below seems to work for us at this point, but should work in most cases (it seems fairly obvious that there are more users than orgs for instance).
- This might be pretty specific to the way the indexes are created in postgresql, with the specific target we're using (github.com/datamill-co/target-postgres/), and may not apply to other databases/targets. @aaronsteers @edgarrmondragon happy to have your thoughts on whether this is too niche to merge. As a counter argument, it probably won't hurt if it doesn't help :)