### PR TITLE
Silence unnecessary replication_key warnings

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -109,7 +109,7 @@ class GitHubStream(RESTStream):
             params["sort"] = "created"
             params["direction"] = "desc"
         # By default, the API returns the data in descending order by creation / timestamp.
-        # Warnig: /commits endpoint accept "since" but results are ordered by descending commit_timestamp
+        # Warning: /commits endpoint accept "since" but results are ordered by descending commit_timestamp
         elif self.replication_key not in ["commit_timestamp", "created_at"]:
             self.logger.warning(
                 f"The replication key '{self.replication_key}' is not fully supported by this client yet."

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -101,7 +101,11 @@ class GitHubStream(RESTStream):
         params: dict = {"per_page": self.MAX_PER_PAGE}
         if next_page_token:
             params["page"] = next_page_token
-        if self.replication_key == "updated_at":
+
+        # By default, the API returns the data in descending order by creation / timestamp.
+        if self.replication_key in ["commit_timestamp", "created_at"]:
+            pass
+        elif self.replication_key == "updated_at":
             params["sort"] = "updated"
             params["direction"] = "asc"
         elif self.replication_key == "starred_at":

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -833,8 +833,7 @@ class IssueEventsStream(GitHubStream):
 class CommitsStream(GitHubStream):
     """
     Defines the 'Commits' stream.
-    The stream is fetched per repository to maximize optimize for API quota
-    usage.
+    The stream is fetched per repository to optimize for API quota usage.
     """
 
     name = "commits"


### PR DESCRIPTION
Tweaking our warning for replication_key handling since "commit_timestamp" and "created_at" work by default.

And leveraging our custom "since" logic to exit early with the "created_at" replication_key