### PR TITLE
Mitigate GitHub API not having "since" parameter for /pulls

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -23,6 +23,10 @@ class GitHubRestStream(RESTStream):
     DEFAULT_API_BASE_URL = "https://api.github.com"
     LOG_REQUEST_METRIC_URLS = True
 
+    # GitHub is missing the "since" parameter on a few endpoints
+    # use this paramter if your stream needs to navigate data in descending order.
+    force_desc = False
+
     _authenticator: Optional[GitHubTokenAuthenticator] = None
 
     @property
@@ -106,7 +110,7 @@ class GitHubRestStream(RESTStream):
 
         if self.replication_key == "updated_at":
             params["sort"] = "updated"
-            params["direction"] = "asc"
+            params["direction"] = "asc" if not self.force_desc else "desc"
         elif self.replication_key == "starred_at":
             params["sort"] = "created"
             params["direction"] = "desc"

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -117,7 +117,7 @@ class GitHubRestStream(RESTStream):
 
         if self.replication_key == "updated_at":
             params["sort"] = "updated"
-            params["direction"] = "asc" if not self.missing_since_parameter else "desc"
+            params["direction"] = "desc" if self.missing_since_parameter else "asc"
 
         # Unfortunately the /starred, /stargazers (starred_at) and /events (created_at) endpoints do not support
         # the "since" parameter out of the box. But we use a workaround in 'get_next_page_token'.

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -86,8 +86,8 @@ class GitHubRestStream(RESTStream):
         # For such streams, we sort by descending dates (most recent first), and paginate
         # "back in time" until we reach records before our "since" parameter.
         request_parameters = parse_qs(str(urlparse(response.request.url).query))
-        since = request_parameters["since"][0]
-        direction = request_parameters["direction"][0]
+        since = request_parameters.get("since", {}).get(0)
+        direction = request_parameters.get("direction", {}).get(0)
         if (
             # commit_timestamp is a constructed key which does not exist in the raw response
             self.replication_key != "commit_timestamp"

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -24,7 +24,7 @@ class GitHubRestStream(RESTStream):
     LOG_REQUEST_METRIC_URLS = True
 
     # GitHub is missing the "since" parameter on a few endpoints
-    # use this paramter if your stream needs to navigate data in descending order
+    # set this parameter to True if your stream needs to navigate data in descending order
     # and try to exit early on its own.
     missing_since_parameter = False
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -82,6 +82,8 @@ class GitHubRestStream(RESTStream):
 
         # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
         # the "since" parameter out of the box. So we use a workaround here to exit early.
+        # For such streams, we sort by descending dates (most recent first), and paginate
+        # "back in time" until we reach records before our "since" parameter.
         request_parameters = parse_qs(str(urlparse(response.request.url).query))
         since = request_parameters["since"][0]
         direction = request_parameters["direction"][0]

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -136,7 +136,7 @@ class GitHubRestStream(RESTStream):
         elif self.replication_key == "commit_timestamp":
             params["direction"] = "desc"
 
-        else:
+        elif self.replication_key:
             self.logger.warning(
                 f"The replication key '{self.replication_key}' is not fully supported by this client yet."
             )

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -84,7 +84,7 @@ class GitHubRestStream(RESTStream):
         # the "since" parameter out of the box. So we use a workaround here to exit early.
         parsed_request_url = urlparse(response.request.url)
         since = parse_qs(str(parsed_request_url.query))["since"][0]
-        direction = parse_qs(str(parsed_request_url.query))["since"][0]
+        direction = parse_qs(str(parsed_request_url.query))["direction"][0]
         if (
             # commit_timestamp is a constructed key which does not exist in the raw response
             self.replication_key != "commit_timestamp"

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -82,9 +82,9 @@ class GitHubRestStream(RESTStream):
 
         # Unfortunately endpoints such as /starred, /stargazers, /events and /pulls do not support
         # the "since" parameter out of the box. So we use a workaround here to exit early.
-        parsed_request_url = urlparse(response.request.url)
-        since = parse_qs(str(parsed_request_url.query))["since"][0]
-        direction = parse_qs(str(parsed_request_url.query))["direction"][0]
+        request_parameters = parse_qs(str(urlparse(response.request.url).query))
+        since = request_parameters["since"][0]
+        direction = request_parameters["direction"][0]
         if (
             # commit_timestamp is a constructed key which does not exist in the raw response
             self.replication_key != "commit_timestamp"

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -86,8 +86,14 @@ class GitHubRestStream(RESTStream):
         # For such streams, we sort by descending dates (most recent first), and paginate
         # "back in time" until we reach records before our "since" parameter.
         request_parameters = parse_qs(str(urlparse(response.request.url).query))
-        since = request_parameters.get("since", {}).get(0)
-        direction = request_parameters.get("direction", {}).get(0)
+        since = (
+            request_parameters["since"][0] if "since" in request_parameters else None
+        )
+        direction = (
+            request_parameters["direction"][0]
+            if "direction" in request_parameters
+            else None
+        )
         if (
             # commit_timestamp is a constructed key which does not exist in the raw response
             self.replication_key != "commit_timestamp"

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -26,6 +26,7 @@ class GitHubRestStream(RESTStream):
     # GitHub is missing the "since" parameter on a few endpoints
     # set this parameter to True if your stream needs to navigate data in descending order
     # and try to exit early on its own.
+    # This only has effect on streams whose `replication_key` is `updated_at`.
     missing_since_parameter = False
 
     _authenticator: Optional[GitHubTokenAuthenticator] = None

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -936,6 +936,8 @@ class PullRequestsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
+    # GitHub is missing the "since" parameter on this endpoint.
+    force_desc = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -341,6 +341,8 @@ class EventsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     def get_records(self, context: Optional[dict] = None) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
@@ -786,6 +788,8 @@ class IssueEventsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = False
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     def get_records(self, context: Optional[dict] = None) -> Iterable[Dict[str, Any]]:
         """Return a generator of row-type dictionary objects.
@@ -937,7 +941,7 @@ class PullRequestsStream(GitHubRestStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
     # GitHub is missing the "since" parameter on this endpoint.
-    force_desc = True
+    missing_since_parameter = True
 
     def get_url_params(
         self, context: Optional[dict], next_page_token: Optional[Any]
@@ -1276,6 +1280,8 @@ class StargazersStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     replication_key = "starred_at"
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/user_streams.py
+++ b/tap_github/user_streams.py
@@ -87,6 +87,8 @@ class StarredStream(GitHubRestStream):
     state_partitioning_keys = ["username"]
     replication_key = "starred_at"
     ignore_parent_replication_key = True
+    # GitHub is missing the "since" parameter on this endpoint.
+    missing_since_parameter = True
 
     @property
     def http_headers(self) -> dict:


### PR DESCRIPTION
As crazy as it sounds, GitHub doesn't have the `since` param on a lot of endpoints.... such as /starred, /stargazers, /events and /pulls, which do not support the "since" parameter out of the box. So we use a workaround here to exit early.