### PR TITLE
Retry on 401 unauthorized errors

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -187,6 +187,14 @@ class GitHubRestStream(RESTStream):
                 self.authenticator.get_next_auth_token()
                 # Raise an error to force a retry with the new token.
                 raise RetriableAPIError(msg)
+            
+            # The GitHub API randomly returns 401 Unauthorized errors, so we try again.
+            if (
+                response.status_code == 401
+                and "unauthorized" in str(response.content).lower()
+            ):
+                raise RetriableAPIError(msg)
+
             raise FatalAPIError(msg)
 
         elif 500 <= response.status_code < 600:

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -187,7 +187,7 @@ class GitHubRestStream(RESTStream):
                 self.authenticator.get_next_auth_token()
                 # Raise an error to force a retry with the new token.
                 raise RetriableAPIError(msg)
-            
+
             # The GitHub API randomly returns 401 Unauthorized errors, so we try again.
             if (
                 response.status_code == 401


### PR DESCRIPTION
Unfortunately, the GitHub API returns 401 unauthorized errors from time to time. Randomly...

To mitigate that, one option is to make 401 a retriable error for now.