### PR TITLE
Add config option to skip API calls to repositories

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -77,15 +77,15 @@ class RepositoryStream(GitHubRestStream):
     def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
         """
         Override the parent method to allow skipping API calls
-        if the stream is deselected and skip_repo_for_child_streams is True in config.
+        if the stream is deselected and skip_parent_streams is True in config.
         This allows running the tap with fewer API calls and preserving
         quota when only syncing a child stream. Without this,
         the API call is sent but data is discarded.
         """
         if (
             not self.selected
-            and "skip_repo_for_child_streams" in self.config
-            and self.config["skip_repo_for_child_streams"]
+            and "skip_parent_streams" in self.config
+            and self.config["skip_parent_streams"]
             and context is not None
         ):
             # build a minimal mock record so that self._sync_records

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -74,6 +74,31 @@ class RepositoryStream(GitHubRestStream):
             "repo": record["name"],
         }
 
+    def get_records(self, context: Optional[dict]) -> Iterable[Dict[str, Any]]:
+        """
+        Override the parent method to allow skipping API calls
+        if the stream is deselected and skip_repo_for_child_streams is True in config.
+        This allows running the tap with fewer API calls and preserving
+        quota when only syncing a child stream. Without this,
+        the API call is sent but data is discarded.
+        """
+        if (
+            not self.selected
+            and "skip_repo_for_child_streams" in self.config
+            and self.config["skip_repo_for_child_streams"]
+            and context is not None
+        ):
+            # build a minimal mock record so that self._sync_records
+            # can proceed with child streams
+            yield {
+                "owner": {
+                    "login": context["org"],
+                },
+                "name": context["repo"],
+            }
+        else:
+            yield from super().get_records(context)
+
     schema = th.PropertiesList(
         th.Property("search_name", th.StringType),
         th.Property("search_query", th.StringType),

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -70,11 +70,11 @@ class TapGitHub(Tap):
         th.Property("stream_maps", th.ObjectType()),
         th.Property("stream_map_config", th.ObjectType()),
         th.Property(
-            "skip_repo_for_child_streams",
+            "skip_parent_streams",
             th.BooleanType,
             description=(
-                "Set to true to skip API calls for the repositories "
-                "streams if it is not selected but children are"
+                "Set to true to skip API calls for the parent "
+                "streams (such as repositories) if it is not selected but children are"
             ),
         ),
     ).to_dict()

--- a/tap_github/tap.py
+++ b/tap_github/tap.py
@@ -69,6 +69,14 @@ class TapGitHub(Tap):
         th.Property("start_date", th.DateTimeType),
         th.Property("stream_maps", th.ObjectType()),
         th.Property("stream_map_config", th.ObjectType()),
+        th.Property(
+            "skip_repo_for_child_streams",
+            th.BooleanType,
+            description=(
+                "Set to true to skip API calls for the repositories "
+                "streams if it is not selected but children are"
+            ),
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
This PR tries to address https://gitlab.com/meltano/sdk/-/issues/217 within `tap-github` using a specific solution.
It might be possible to generalise the idea and add something equivalent in the sdk.

This has become fairly high priority for us:
- we sync different streams independently (1 by 1) at different frequencies (some hourly, some daily, some less often). Currently all child streams force a call to the `/repo` endpoint.
- github API quota usage is essentially doubled in incremental mode. eg: syncing `issues` for 1 repo yields 2 API calls, 1 to repos, 1 to issues, and the result of the first call is discarded, which seems wasteful.
- we have seen an increase in random 401 errors from the API (despite valid auth, and remaining within rate limits), these lead to the tap crashing with no real solution we can implement (see https://gitlab.com/meltano/sdk/-/issues/282). While this PR does not directly fix this, it should help by reducing the number of API calls and potential for errors.
- it's just nice to avoid doing work that we don't need :)