### PR TITLE
Fix broken timestamp in ci with requests-cache

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -79,9 +79,13 @@ class GitHubRestStream(RESTStream):
 
         if self.replication_key in ["starred_at", "created_at"]:
             parsed_request_url = urlparse(response.request.url)
-            since = parse_qs(str(parsed_request_url.query))["since"][0]
-            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
-            since = since.replace(" ", "+")
+            try:
+                params = parse_qs(str(parsed_request_url.query))
+                since = params["since"][0]
+                # parse_qs interprets "+" as a space, revert this to keep an aware datetime
+                since = since.replace(" ", "+")
+            except IndexError:
+                since = ""
             if since and (parse(results[-1][self.replication_key]) < parse(since)):
                 return None
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -80,6 +80,8 @@ class GitHubRestStream(RESTStream):
         if self.replication_key in ["starred_at", "created_at"]:
             parsed_request_url = urlparse(response.request.url)
             since = parse_qs(str(parsed_request_url.query))["since"][0]
+            # parse_qs interprets "+" as a space, revert this to keep an aware datetime
+            since = since.replace(" ", "+")
             if since and (parse(results[-1][self.replication_key]) < parse(since)):
                 return None
 


### PR DESCRIPTION
This PR should fix the CI failures we have seen such as https://github.com/MeltanoLabs/tap-github/actions/runs/1898146133

The failures are caused by `requests-cache` which serializes `since` with a `+00:00` timezone format instead of `Z`, and when parsed by `parse_qs`, the `+` is turned into a space.
`parse` then sees a naive timestamp, and tests fail. This only happens in CI, but the fix below has no impact elsewhere as there are no spaces in the string.