### PR TITLE
Support latest minor python 3.10.x versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["AJ Steers (Meltano)"]
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<=3.10.1,>=3.7.2"
+python = "<3.11,>=3.7.2"
 requests = "^2.25.1"
 singer-sdk = "^0.4.1"
 # For local SDK dev:


### PR DESCRIPTION
This fixes the version definition to allow using python 3.10.2+ (current stable python is 3.10.3).
