### PR TITLE
Correct error handling for http 401 codes

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -182,7 +182,7 @@ class GitHubRestStream(RESTStream):
         if 400 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
-                f"{response.content} for path: {full_path}"
+                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
             )
             # Retry on rate limiting
             if (

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -211,7 +211,7 @@ class GitHubRestStream(RESTStream):
         elif 500 <= response.status_code < 600:
             msg = (
                 f"{response.status_code} Server Error: "
-                f"{response.reason} for path: {full_path}"
+                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
             )
             raise RetriableAPIError(msg)
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -182,7 +182,7 @@ class GitHubRestStream(RESTStream):
         if 400 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
-                f"{response.reason} for path: {full_path}"
+                f"{response.content} for path: {full_path}"
             )
             # Retry on rate limiting
             if (
@@ -198,10 +198,9 @@ class GitHubRestStream(RESTStream):
             if (
                 response.status_code == 401
                 and "unauthorized" in str(response.reason).lower()
+                # if the token is invalid, we are also told about it
+                and not "bad credentials" in str(response.content).lower()
             ):
-                # if the token is invalid however, we are also told about it
-                if "bad credentials" in str(response.content).lower():
-                    raise FatalAPIError("Auth token provided is invalid")
                 raise RetriableAPIError(msg)
 
             # all other errors are fatal

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -174,7 +174,7 @@ class GitHubRestStream(RESTStream):
         if response.status_code in self.tolerated_http_errors:
             msg = (
                 f"{response.status_code} Tolerated Status Code: "
-                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
+                f"{str(response.content)} (Reason: {response.reason}) for path: {full_path}"
             )
             self.logger.info(msg)
             return
@@ -182,7 +182,7 @@ class GitHubRestStream(RESTStream):
         if 400 <= response.status_code < 500:
             msg = (
                 f"{response.status_code} Client Error: "
-                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
+                f"{str(response.content)} (Reason: {response.reason}) for path: {full_path}"
             )
             # Retry on rate limiting
             if (
@@ -211,7 +211,7 @@ class GitHubRestStream(RESTStream):
         elif 500 <= response.status_code < 600:
             msg = (
                 f"{response.status_code} Server Error: "
-                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
+                f"{str(response.content)} (Reason: {response.reason}) for path: {full_path}"
             )
             raise RetriableAPIError(msg)
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -174,7 +174,7 @@ class GitHubRestStream(RESTStream):
         if response.status_code in self.tolerated_http_errors:
             msg = (
                 f"{response.status_code} Tolerated Status Code: "
-                f"{response.reason} for path: {full_path}"
+                f"{response.content} (Reason: {response.reason}) for path: {full_path}"
             )
             self.logger.info(msg)
             return

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -197,7 +197,6 @@ class GitHubRestStream(RESTStream):
             # The GitHub API randomly returns 401 Unauthorized errors, so we try again.
             if (
                 response.status_code == 401
-                and "unauthorized" in str(response.reason).lower()
                 # if the token is invalid, we are also told about it
                 and not "bad credentials" in str(response.content).lower()
             ):


### PR DESCRIPTION
This PR corrects how the tap handles HTTP 401 error codes from the API:
the `Unauthorized` string appears in `response.reason` not `response.content`.

It also adds a fatal error if the token in invalid as there is no point retrying in that case.