### PR TITLE
Add repo context to commits stream

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -880,9 +880,14 @@ class CommitsStream(GitHubRestStream):
         is used to compare to the `since` argument that the endpoint supports.
         """
         row["commit_timestamp"] = row["commit"]["committer"]["date"]
+        # add some context info to help downstream processing
+        row["repo"] = context["repo"]
+        row["org"] = context["org"]
         return row
 
     schema = th.PropertiesList(
+        th.Property("org", th.StringType),
+        th.Property("repo", th.StringType),
         th.Property("node_id", th.StringType),
         th.Property("url", th.StringType),
         th.Property("sha", th.StringType),

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -881,6 +881,7 @@ class CommitsStream(GitHubRestStream):
         """
         row["commit_timestamp"] = row["commit"]["committer"]["date"]
         # add some context info to help downstream processing
+        assert context is not None, "CommitsStream was called without context"
         row["repo"] = context["repo"]
         row["org"] = context["org"]
         return row


### PR DESCRIPTION
This PR adds `repo, org` to commit records to help downstream processing, for instance to filter by repo.
Right now it's actually difficult to do so, as it would require filtering records whose url contains the repo name, or something along those lines.