### PR TITLE
Avoid printing out "error" in tolerated status code message

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -173,8 +173,8 @@ class GitHubRestStream(RESTStream):
         full_path = urlparse(response.url).path
         if response.status_code in self.tolerated_http_errors:
             msg = (
-                f"{response.status_code} Tolerated Status Code: "
-                f"{str(response.content)} (Reason: {response.reason}) for path: {full_path}"
+                f"{response.status_code} Tolerated Status Code "
+                f"(Reason: {response.reason}) for path: {full_path}"
             )
             self.logger.info(msg)
             return


### PR DESCRIPTION
With the current logging implementation, we end up printing the word "error" for tolerated status codes.

Eg. `502 Tolerated Status Code: b'{\n  "message": "Server Error"\n}\n' (Reason: Bad Gateway) for path: /repos/kubevirt/kubevirt/issues/comments`

Instead, I propose to remove the content print and simplify the message to:

`502 Tolerated Status Code (Reason: Bad Gateway) for path: /repos/kubevirt/kubevirt/issues/comments`

