### PR TITLE
Release pinning guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Build with the [Singer SDK](https://gitlab.com/meltano/singer-sdk).
 pipx install git+https://github.com/MeltanoLabs/tap-github.git
 ```
 
+Or better yet, please pin to a [release version](https://github.com/MeltanoLabs/tap-github/releases) for a stable experience:
+
+```bash
+pipx install git+https://github.com/MeltanoLabs/tap-github.git@vX.Y.Z
+```
+
+A list of release versions is available at https://github.com/MeltanoLabs/tap-github/releases
+
 ## Configuration
 
 ### Accepted Config Options


### PR DESCRIPTION
Adds guidance on how to pin to a specific release version.