### PR TITLE
Enable GitHub App authentication with private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This tap accepts the following configuration options:
   - `auth_token` - GitHub token to authenticate with.
   - `additional_auth_tokens` - List of GitHub tokens to authenticate with. Streams will loop through them when hitting rate limits..
   - alternatively, you can input authentication tokens with any environment variables starting with GITHUB_TOKEN.
-  - or authenticate as a GitHub app setting a private key in GITHUB_APP_PRIVATE_KEY. Formatted as follows: `:app_id:;;-----BEGIN RSA PRIVATE KEY-----\n_YOUR_P_KEY_\n-----END RSA PRIVATE KEY-----`
+  - or authenticate as a GitHub app setting a private key in GITHUB_APP_PRIVATE_KEY. Formatted as follows: `:app_id:;;-----BEGIN RSA PRIVATE KEY-----\n_YOUR_P_KEY_\n-----END RSA PRIVATE KEY-----`. You can generate it from the `Private keys` section on https://github.com/organizations/:organization_name/settings/apps/:app_name. Read more about GitHub App quotas [here](https://docs.github.com/en/enterprise-server@3.3/developers/apps/building-github-apps/rate-limits-for-github-apps#server-to-server-requests).
 - Optional:
   - `user_agent`
   - `start_date`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This tap accepts the following configuration options:
   - `auth_token` - GitHub token to authenticate with.
   - `additional_auth_tokens` - List of GitHub tokens to authenticate with. Streams will loop through them when hitting rate limits..
   - alternatively, you can input authentication tokens with any environment variables starting with GITHUB_TOKEN.
+  - or authenticate as a GitHub app setting a private key in GITHUB_APP_PRIVATE_KEY. Formatted as follows: `:app_id:;;-----BEGIN RSA PRIVATE KEY-----\n_YOUR_P_KEY_\n-----END RSA PRIVATE KEY-----`
 - Optional:
   - `user_agent`
   - `start_date`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["Meltano and Meltano Community"]
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
+PyJWT = "2.3.0"
 python = "<3.11,>=3.7.2"
 requests = "^2.25.1"
 singer-sdk = "^0.4.1"

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -77,8 +77,8 @@ def generate_jwt_token(
 
 
 def generate_app_access_token(
-    github_app_id, github_private_key, github_installation_id=None
-):
+    github_app_id: str, github_private_key: str, github_installation_id: Optional[str] = None
+) -> str:
     jwt_token = generate_jwt_token(github_app_id, github_private_key)
 
     headers = {"Authorization": "Bearer {}".format(jwt_token)}

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -134,8 +134,8 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             # "{app_id}$${-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"
             parts = environ["GITHUB_APP_PRIVATE_KEY"].split(";;")
             github_app_id = parts[0]
-            github_private_key = (parts[1:2] or [''])[0].replace('\\n', '\n')
-            github_installation_id = (parts[2:3] or [''])[0]
+            github_private_key = (parts[1:2] or [""])[0].replace("\\n", "\n")
+            github_installation_id = (parts[2:3] or [""])[0]
 
             if not (github_private_key):
                 self.logger.warning(
@@ -144,13 +144,13 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
                         '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\n_YOUR_P_KEY_\n-----END RSA PRIVATE KEY-----"'
                     )
                 )
-    
+
             else:
                 app_token = generate_app_access_token(
                     github_app_id, github_private_key, github_installation_id or None
                 )
                 available_tokens = available_tokens + [app_token]
-    
+
         self.logger.info(f"Tap will run with {len(available_tokens)} auth tokens")
 
         # Get rate_limit_buffer

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -64,10 +64,12 @@ def generate_jwt_token(
     actual_time = int(time.time())
 
     payload = {
-        "iat": actual_time, "exp": actual_time + expiration_time, "iss": github_app_id,
+        "iat": actual_time,
+        "exp": actual_time + expiration_time,
+        "iss": github_app_id,
     }
-    token = jwt.encode(payload, github_private_key, algorithm=algorithm).
-    
+    token = jwt.encode(payload, github_private_key, algorithm=algorithm)
+
     if isinstance(token, bytes):
         token = token.decode("utf-8")
 
@@ -75,7 +77,7 @@ def generate_jwt_token(
 
 
 def generate_app_access_token(
-    self, github_app_id, github_private_key, github_installation_id=None
+    github_app_id, github_private_key, github_installation_id=None
 ):
     jwt_token = generate_jwt_token(github_app_id, github_private_key)
 
@@ -93,12 +95,10 @@ def generate_app_access_token(
 
         github_installation_id = random.choice(list_installations)["id"]
 
-        self.logger.warning(list_installations)
-
     url = "https://api.github.com/app/installations/{}/access_tokens".format(
         github_installation_id
     )
-    resp = requests.get(url, headers=headers)
+    resp = requests.post(url, headers=headers)
 
     if resp.status_code != 201:
         resp.raise_for_status()

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -59,7 +59,10 @@ class TokenRateLimit:
 
 
 def generate_jwt_token(
-    github_app_id: str, github_private_key: str, expiration_time: int = 600, algorithm: str = "RS256"
+    github_app_id: str,
+    github_private_key: str,
+    expiration_time: int = 600,
+    algorithm: str = "RS256",
 ) -> str:
     actual_time = int(time.time())
 
@@ -77,11 +80,13 @@ def generate_jwt_token(
 
 
 def generate_app_access_token(
-    github_app_id: str, github_private_key: str, github_installation_id: Optional[str] = None
+    github_app_id: str,
+    github_private_key: str,
+    github_installation_id: Optional[str] = None,
 ) -> str:
     jwt_token = generate_jwt_token(github_app_id, github_private_key)
 
-    headers = {"Authorization": "Bearer {}".format(jwt_token)}
+    headers = {"Authorization": f"Bearer {jwt_token}"}
 
     if github_installation_id is None:
         list_installations_resp = requests.get(
@@ -131,7 +136,7 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
 
         if "GITHUB_APP_PRIVATE_KEY" in environ.keys():
             # To simplify settings, we use a single env-key formatted as follows:
-            # "{app_id}$${-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"
+            # "{app_id};;{-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"
             parts = environ["GITHUB_APP_PRIVATE_KEY"].split(";;")
             github_app_id = parts[0]
             github_private_key = (parts[1:2] or [""])[0].replace("\\n", "\n")

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -133,6 +133,7 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
                 )
                 available_tokens = env_tokens
 
+        # Parse App level private key and generate a token
         if "GITHUB_APP_PRIVATE_KEY" in environ.keys():
             # To simplify settings, we use a single env-key formatted as follows:
             # "{app_id};;{-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -161,12 +161,9 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
         rate_limit_buffer = self._config.get("rate_limit_buffer", None)
 
         # Dedup tokens and create a dict of TokenRateLimit
-        # Detect org level token input and fetch actual token
-        # final_tokens = []
 
         # TODO - separate app_token and add logic to refresh the token
         # using generate_app_access_token.
-
         return {
             token: TokenRateLimit(token, rate_limit_buffer)
             for token in list(set(available_tokens))

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -59,8 +59,8 @@ class TokenRateLimit:
 
 
 def generate_jwt_token(
-    github_app_id, github_private_key, expiration_time=600, algorithm="RS256"
-):
+    github_app_id: str, github_private_key: str, expiration_time: int = 600, algorithm: str = "RS256"
+) -> str:
     actual_time = int(time.time())
 
     payload = {

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -1,7 +1,6 @@
 """Classes to assist in authenticating to the GitHub API."""
 
 import logging
-import random
 import time
 from datetime import datetime
 from os import environ
@@ -98,7 +97,7 @@ def generate_app_access_token(
         if len(list_installations) == 0:
             raise Exception(f"No installations found for app {github_app_id}.")
 
-        github_installation_id = random.choice(list_installations)["id"]
+        github_installation_id = choice(list_installations)["id"]
 
     url = "https://api.github.com/app/installations/{}/access_tokens".format(
         github_installation_id


### PR DESCRIPTION
Adding an environment variable GITHUB_APP_PRIVATE_KEY to enable authentication as a GitHub app which have higher API limits.

https://docs.github.com/en/enterprise-server@3.3/developers/apps/building-github-apps/rate-limits-for-github-apps#server-to-server-requests

GitHub Apps making server-to-server requests use the installation's minimum rate limit of 5,000 requests per hour. If an application is installed on an organization with more than 20 users, the application receives another 50 requests per hour for each user. Installations that have more than 20 repositories receive another 50 requests per hour for each repository. The maximum rate limit for an installation is 12,500 requests per hour.