### PR TITLE
Fetch databaseId for repos and users when initializing streams

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     repo_list: mark a test as a repo_list.
+    username_list: make a test as using a list of usernames in config

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 markers =
-    repo_list: mark a test as a repo_list.
-    username_list: make a test as using a list of usernames in config
+    repo_list: mark a test as using a list of repos in config
+    username_list: mark a test as using a list of usernames in config

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -234,8 +234,10 @@ class GitHubRestStream(RESTStream):
 
         yield from results
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
+    def post_process(self, row: dict, context: Optional[Dict[str, str]] = None) -> dict:
         """Add `repo_id` by default to all streams."""
+        if context is None:
+            return row
         row["repo_id"] = context["repo_id"]
         return row
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -236,9 +236,8 @@ class GitHubRestStream(RESTStream):
 
     def post_process(self, row: dict, context: Optional[Dict[str, str]] = None) -> dict:
         """Add `repo_id` by default to all streams."""
-        if context is None:
-            return row
-        row["repo_id"] = context["repo_id"]
+        if context is not None and "repo_id" in context:
+            row["repo_id"] = context["repo_id"]
         return row
 
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -234,6 +234,11 @@ class GitHubRestStream(RESTStream):
 
         yield from results
 
+    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
+        """Add `repo_id` by default to all streams."""
+        row["repo_id"] = context["repo_id"]
+        return row
+
 
 class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
     """GitHub Graphql stream class."""

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -442,7 +442,8 @@ class EventsStream(GitHubRestStream):
         # the parent stream, e.g. for fork/parent PR events.
         row["target_repo"] = row.pop("repo", None)
         row["target_org"] = row.pop("org", None)
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         return row
 
     schema = th.PropertiesList(
@@ -813,7 +814,8 @@ class IssuesStream(GitHubRestStream):
         # replace +1/-1 emojis to avoid downstream column name errors.
         row["plus_one"] = row.pop("+1", None)
         row["minus_one"] = row.pop("-1", None)
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         return row
 
     schema = th.PropertiesList(
@@ -890,7 +892,8 @@ class IssueCommentsStream(GitHubRestStream):
 
     def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
         row["issue_number"] = int(row["issue_url"].split("/")[-1])
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         if row["body"] is not None:
             # some comment bodies include control characters such as \x00
             # that some targets (such as postgresql) choke on. This ensures
@@ -950,7 +953,8 @@ class IssueEventsStream(GitHubRestStream):
     def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
         row["issue_number"] = int(row["issue"].pop("number"))
         row["issue_url"] = row["issue"].pop("url")
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         return row
 
     schema = th.PropertiesList(
@@ -1125,7 +1129,8 @@ class PullRequestsStream(GitHubRestStream):
         # replace +1/-1 emojis to avoid downstream column name errors.
         row["plus_one"] = row.pop("+1", None)
         row["minus_one"] = row.pop("-1", None)
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         return row
 
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
@@ -1496,7 +1501,8 @@ class StargazersStream(GitHubRestStream):
         Add a user_id top-level field to be used as state replication key.
         """
         row["user_id"] = row["user"]["id"]
-        row["repo_id"] = context["repo_id"]
+        if context is not None:
+            row["repo_id"] = context["repo_id"]
         return row
 
     schema = th.PropertiesList(

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -112,7 +112,7 @@ class RepositoryStream(GitHubRestStream):
                     )
                     continue
                 repos_with_ids.append(
-                    {"org": org, "repo": repo, "id": record[item]["databaseId"]}
+                    {"org": org, "repo": repo, "repo_id": record[item]["databaseId"]}
                 )
         self.logger.info(f"Running the tap on {len(repos_with_ids)} repositories")
         return repos_with_ids

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1169,12 +1169,14 @@ class PullRequestsStream(GitHubRestStream):
             return {
                 "org": context["org"],
                 "repo": context["repo"],
+                "repo_id": context["repo_id"],
                 "pull_number": record["number"],
             }
         return {
             "pull_number": record["number"],
             "org": record["base"]["user"]["login"],
             "repo": record["base"]["repo"]["name"],
+            "repo_id": record["base"]["repo"]["id"],
         }
 
     schema = th.PropertiesList(

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1588,7 +1588,12 @@ class ProjectsStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
 
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
-        return {"project_id": record["id"]}
+        return {
+            "project_id": record["id"],
+            "repo_id": context["repo_id"] if context else None,
+            "org": context["org"] if context else None,
+            "repo": context["repo"] if context else None,
+        }
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1622,7 +1627,12 @@ class ProjectColumnsStream(GitHubRestStream):
     state_partitioning_keys = ["project_id", "repo", "org"]
 
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
-        return {"column_id": record["id"]}
+        return {
+            "column_id": record["id"],
+            "repo_id": context["repo_id"] if context else None,
+            "org": context["org"] if context else None,
+            "repo": context["repo"] if context else None,
+        }
 
     schema = th.PropertiesList(
         # Parent Keys
@@ -1774,6 +1784,7 @@ class WorkflowRunsStream(GitHubRestStream):
             "org": context["org"] if context else None,
             "repo": context["repo"] if context else None,
             "run_id": record["id"],
+            "repo_id": context["repo_id"] if context else None,
         }
 
 

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -253,10 +253,6 @@ class ReadmeStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
     tolerated_http_errors = [404]
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -317,10 +313,6 @@ class ReadmeHtmlStream(GitHubRestStream):
 
         yield {"raw_html": response.text}
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -341,10 +333,6 @@ class CommunityProfileStream(GitHubRestStream):
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]
     tolerated_http_errors = [404]
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent Keys
@@ -598,10 +586,6 @@ class MilestonesStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = True
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -635,10 +619,6 @@ class ReleasesStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
     replication_key = "published_at"
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -703,10 +683,6 @@ class LanguagesStream(GitHubRestStream):
         for key, value in languages_json.items():
             yield {"language_name": key, "bytes": value}
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -726,10 +702,6 @@ class CollaboratorsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent Keys
@@ -769,10 +741,6 @@ class AssigneesStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1090,10 +1058,6 @@ class CommitCommentsStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
     ignore_parent_replication_key = True
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("repo", th.StringType),
@@ -1284,10 +1248,6 @@ class PullRequestCommits(GitHubRestStream):
     parent_stream_type = PullRequestsStream
     state_partitioning_keys = ["repo", "org"]
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("org", th.StringType),
@@ -1361,10 +1321,6 @@ class ReviewsStream(GitHubRestStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("pull_number", th.IntegerType),
@@ -1401,10 +1357,6 @@ class ReviewCommentsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1459,10 +1411,6 @@ class ContributorsStream(GitHubRestStream):
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("repo", th.StringType),
@@ -1506,10 +1454,6 @@ class AnonymousContributorsStream(GitHubRestStream):
         """Parse the response and return an iterator of anonymous contributors."""
         parsed_response = super().parse_response(response)
         return filter(lambda x: x["type"] == "Anonymous", parsed_response)
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1607,10 +1551,6 @@ class StatsContributorsStream(GitHubRestStream):
                 week_with_author["user_id"] = week_with_author.pop("id")
                 yield week_with_author
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("repo", th.StringType),
@@ -1643,10 +1583,6 @@ class ProjectsStream(GitHubRestStream):
 
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
         return {"project_id": record["id"]}
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1682,10 +1618,6 @@ class ProjectColumnsStream(GitHubRestStream):
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
         return {"column_id": record["id"]}
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("repo", th.StringType),
@@ -1712,10 +1644,6 @@ class ProjectCardsStream(GitHubRestStream):
     primary_keys = ["id"]
     parent_stream_type = ProjectColumnsStream
     state_partitioning_keys = ["project_id", "repo", "org"]
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent Keys
@@ -1753,10 +1681,6 @@ class WorkflowsStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
     records_jsonpath = "$.workflows[*]"
 
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("repo", th.StringType),
@@ -1791,10 +1715,6 @@ class WorkflowRunsStream(GitHubRestStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org"]
     records_jsonpath = "$.workflow_runs[*]"
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys
@@ -1863,10 +1783,6 @@ class WorkflowRunJobsStream(GitHubRestStream):
     ignore_parent_replication_key = False
     state_partitioning_keys = ["repo", "org", "run_id"]
     records_jsonpath = "$.jobs[*]"
-
-    def post_process(self, row: dict, context: Optional[Dict] = None) -> dict:
-        row["repo_id"] = context["repo_id"]
-        return row
 
     schema = th.PropertiesList(
         # Parent keys

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -171,7 +171,7 @@ class RepositoryStream(GitHubRestStream):
                     "login": context["org"],
                 },
                 "name": context["repo"],
-                "id": context["id"],
+                "id": context["repo_id"],
             }
         else:
             yield from super().get_records(context)

--- a/tap_github/tests/__init__.py
+++ b/tap_github/tests/__init__.py
@@ -11,9 +11,13 @@ requests_cache.install_cache(
     "api_calls_tests_cache",
     backend="sqlite",
     # make sure that API keys don't end up being cached
-    ignored_parameters=["Authorization"],
+    # Also ignore user-agent so that various versions of request
+    # can share the cache
+    ignored_parameters=["Authorization", "user-agent"],
     # tell requests_cache to check headers for the above parameter
     match_headers=True,
     # expire the cache after 24h (86400 seconds)
     expire_after=24 * 60 * 60,
+    # make sure graphql calls get cached as well
+    allowable_methods=["GET", "POST"],
 )

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -13,13 +13,25 @@ repo_list_2 = [
     "MeltanoLabs/tap-gitlab",
     "MeltanoLabs/target-athena",
 ]
+# the github repo ids that match the repo names above
+# in the same order
+repo_ids = [
+    365087920,
+    416891176,
+    361619143,
+]
 
 
 @pytest.mark.repo_list(repo_list_2)
 def test_validate_repo_list_config(repo_list_config):
     """Verify that the repositories list is parsed correctly"""
     repo_list_context = [
-        {"org": repo.split("/")[0], "repo": repo.split("/")[1]} for repo in repo_list_2
+        {
+            "org": repo[0].split("/")[0],
+            "repo": repo[0].split("/")[1],
+            "repo_id": repo[1],
+        }
+        for repo in zip(repo_list_2, repo_ids)
     ]
     tap = TapGitHub(config=repo_list_config)
     partitions = tap.streams["repositories"].partitions

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -15,7 +15,7 @@ repo_list_2 = [
 ]
 # the github repo ids that match the repo names above
 # in the same order
-repo_ids = [
+repo_list_2_ids = [
     365087920,
     416891176,
     361619143,

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -15,6 +15,12 @@ repo_list_2 = [
     # mistype the org
     "meltanolabs/target-athena",
 ]
+# the same list, but without typos, for validation
+repo_list_2_corrected = [
+    "MeltanoLabs/tap-github",
+    "MeltanoLabs/tap-gitlab",
+    "MeltanoLabs/target-athena",
+]
 # the github repo ids that match the repo names above
 # in the same order
 repo_list_2_ids = [
@@ -33,7 +39,7 @@ def test_validate_repo_list_config(repo_list_config):
             "repo": repo[0].split("/")[1],
             "repo_id": repo[1],
         }
-        for repo in zip(repo_list_2, repo_list_2_ids)
+        for repo in zip(repo_list_2_corrected, repo_list_2_ids)
     ]
     tap = TapGitHub(config=repo_list_config)
     partitions = tap.streams["repositories"].partitions

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -6,12 +6,14 @@ from unittest.mock import patch
 
 from tap_github.tap import TapGitHub
 
-from .fixtures import repo_list_config
+from .fixtures import repo_list_config, username_list_config
 
 repo_list_2 = [
     "MeltanoLabs/tap-github",
-    "MeltanoLabs/tap-gitlab",
-    "MeltanoLabs/target-athena",
+    # mistype the repo name so we can check that the tap corrects it
+    "MeltanoLabs/Tap-GitLab",
+    # mistype the org
+    "meltanolabs/target-athena",
 ]
 # the github repo ids that match the repo names above
 # in the same order
@@ -31,7 +33,7 @@ def test_validate_repo_list_config(repo_list_config):
             "repo": repo[0].split("/")[1],
             "repo_id": repo[1],
         }
-        for repo in zip(repo_list_2, repo_ids)
+        for repo in zip(repo_list_2, repo_list_2_ids)
     ]
     tap = TapGitHub(config=repo_list_config)
     partitions = tap.streams["repositories"].partitions
@@ -63,29 +65,53 @@ def alternative_sync_chidren(self, child_context: dict) -> None:
             child_stream.sync(context=child_context)
 
 
-@pytest.mark.repo_list(repo_list_2)
-def test_get_a_repository_in_repo_list_mode(capsys, repo_list_config):
+def run_tap_with_config(capsys, config_obj) -> str:
     """
-    Discover the catalog, and request 2 repository records
+    Run the tap with the given config and capture stdout
     """
-    tap1 = TapGitHub(config=repo_list_config)
+    tap1 = TapGitHub(config=config_obj)
     tap1.run_discovery()
     catalog = tap1.catalog_dict
-    # disable child streams
-    # FIXME: this does not work, the child streams are still fetched
-    # deselect_all_streams(catalog)
-    # set_catalog_stream_selected(
-    #     catalog=catalog, stream_name="repositories", selected=True
-    # )
     # discard previous output to stdout (potentially from other tests)
     capsys.readouterr()
     with patch(
         "singer_sdk.streams.core.Stream._sync_children", alternative_sync_chidren
     ):
-        tap2 = TapGitHub(config=repo_list_config, catalog=catalog)
+        tap2 = TapGitHub(config=config_obj, catalog=catalog)
         tap2.sync_all()
     captured = capsys.readouterr()
+    return captured.out
+
+
+@pytest.mark.repo_list(repo_list_2)
+def test_get_a_repository_in_repo_list_mode(capsys, repo_list_config):
+    """
+    Discover the catalog, and request 2 repository records
+    """
+    captured_out = run_tap_with_config(capsys, repo_list_config)
     # Verify we got the right number of records (one per repo in the list)
-    assert captured.out.count('{"type": "RECORD", "stream": "repositories"') == len(
+    assert captured_out.count('{"type": "RECORD", "stream": "repositories"') == len(
         repo_list_2
     )
+    # check that the tap corrects invalid case in config input
+    assert '"repo": "Tap-GitLab"' not in captured_out
+    assert '"org": "meltanolabs"' not in captured_out
+
+
+# case is incorrect on purpose, so we can check that the tap corrects it
+@pytest.mark.repo_list(["EricBoucher", "aaRONsTeeRS"])
+def test_get_a_user_in_user_usernames_mode(capsys, username_list_config):
+    """
+    Discover the catalog, and request 2 repository records
+    """
+    captured_out = run_tap_with_config(capsys, username_list_config)
+    # Verify we got the right number of records (one per user in the list)
+    assert captured_out.count('{"type": "RECORD", "stream": "users"') == len(
+        username_list_config["user_usernames"]
+    )
+    # these 2 are inequalities as number will keep changing :)
+    assert captured_out.count('{"type": "RECORD", "stream": "starred"') > 150
+    assert captured_out.count('{"type": "RECORD", "stream": "user_contributed_to"') > 50
+    assert '{"username": "aaronsteers"' in captured_out
+    assert '{"username": "aaRONsTeeRS"' not in captured_out
+    assert '{"username": "EricBoucher"' not in captured_out

--- a/tap_github/user_streams.py
+++ b/tap_github/user_streams.py
@@ -34,6 +34,7 @@ class UserStream(GitHubRestStream):
     def get_child_context(self, record: Dict, context: Optional[Dict]) -> dict:
         return {
             "username": record["login"],
+            "user_id": record["id"],
         }
 
     schema = th.PropertiesList(
@@ -102,12 +103,15 @@ class StarredStream(GitHubRestStream):
         Add a repo_id top-level field to be used as state replication key.
         """
         row["repo_id"] = row["repo"]["id"]
+        if context is not None:
+            row["user_id"] = context["user_id"]
         return row
 
     schema = th.PropertiesList(
         # Parent Keys
         th.Property("username", th.StringType),
         th.Property("repo_id", th.StringType),
+        th.Property("user_id", th.IntegerType),
         # Starred Repo Info
         th.Property("starred_at", th.DateTimeType),
         th.Property(


### PR DESCRIPTION
This PR aims to resolve a number of issues by adding the numeric repo id to the context of all streams in the tap.

We have been having issues with repos changing names, incorrect case in the config file, etc... leading to problems with joins downstream. We are using `org/repo` to connect the various streams together, but since those values are not stable (for instance if a repo is renamed), this can lead to issues.

To remedy this, we fetch the github `id` (or `databaseId` in their graphql API lingo) and add it to all streams via the child context. This `id` is stable across renames, which should help match records over time.

The PR adds a "preflight" request to the graphql API which fetches said `id` for all the repos in the config file (if `repositories` is indeed in the config). At the same time, it:
- gets the correct casing for mistyped names (so `meltanolabs/tap-github` is corrected to `MeltanoLabs/tap-github`, see #110)
- gets new names for repos that have been renamed (running a REST API call on `myorg/oldname` will return an HTTP 301, but we save this step here)
- filters out repos which don't exist and issues a warning in the logs for each of them. @aaronsteers you mentioned elsewhere that you'd be in favour of letting the tap error out, does the above seem like an acceptable trade-off to you? 

These changes should help increase the resilience of the tap to invalid manual input, as well as repo renames. If this logic seems ok to everyone, we can also apply it to the user streams, as username are likely to change more often than repo names.