### PR TITLE
Cast DenpendenciesStream.url as String

### DIFF
--- a/.secrets/.gitignore
+++ b/.secrets/.gitignore
@@ -1,0 +1,6 @@
+# IMPORTANT! This folder is hidden from git - if you need to store config files or other secrets,
+# make sure those are never staged for commit into your git repo. You can store them here or another
+# secure location.
+
+*
+!.gitignore

--- a/.secrets/.gitignore
+++ b/.secrets/.gitignore
@@ -1,6 +1,0 @@
-# IMPORTANT! This folder is hidden from git - if you need to store config files or other secrets,
-# make sure those are never staged for commit into your git repo. You can store them here or another
-# secure location.
-
-*
-!.gitignore

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1591,7 +1591,7 @@ class StargazersGraphqlStream(GitHubGraphqlStream):
         # Graphql id is equivalent to REST node_id. To keep the tap consistent, we rename "id" to "node_id".
         return """
           query repositoryStargazers($repo: String! $org: String! $nextPageCursor_0: String) {
-            repository(name: $repo owner: $org) { 
+            repository(name: $repo owner: $org) {
               stargazers(first: 100 orderBy: {field: STARRED_AT direction: DESC} after: $nextPageCursor_0) {
                 pageInfo {
                   hasNextPage_0: hasNextPage
@@ -2124,7 +2124,7 @@ class DependenciesStream(GitHubGraphqlStream):
                 th.Property("node_id", th.StringType),
                 th.Property("id", th.IntegerType),
                 th.Property("name_with_owner", th.StringType),
-                th.Property("url", th.IntegerType),
+                th.Property("url", th.StringType),
                 th.Property(
                     "owner",
                     th.ObjectType(


### PR DESCRIPTION
### Ticket ([DE-291](https://potloc.atlassian.net/browse/DE-291))

> *What*
> 
> Dependencies url is cast as integer instead of string → Causes tap to fail

---
_from `tiguidou` with :heart:_
