### PR TITLE
Wait and retry on secondary limits

### DIFF
--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -33,7 +33,7 @@ jobs:
         path: 'api_calls_tests_cache.sqlite'
         # github cache expires after 1wk, and we expire the content after 24h
         # this key should not need to change unless we need to clear the cache
-        key: api-cache-v3
+        key: api-cache-v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -33,7 +33,7 @@ jobs:
         path: 'api_calls_tests_cache.sqlite'
         # github cache expires after 1wk, and we expire the content after 24h
         # this key should not need to change unless we need to clear the cache
-        key: api-cache-v4
+        key: api-cache-v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -50,7 +50,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-2-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
+        key: venv-3-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         poetry install

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -2,6 +2,7 @@
 
 import collections
 import inspect
+import random
 import re
 import time
 from types import FrameType
@@ -209,8 +210,8 @@ class GitHubRestStream(RESTStream):
                 response.status_code == 403
                 and "secondary rate limit" in str(response.content).lower()
             ):
-                # Wait a minuteand retry
-                time.sleep(61)
+                # Wait about a minute and retry
+                time.sleep(60 + 30 * random.random())
                 raise RetriableAPIError(msg, response)
 
             # The GitHub API randomly returns 401 Unauthorized errors, so we try again.


### PR DESCRIPTION
When heavily using the GitHub API, users can encounter "secondary rate limits". This happens in particular when multiple streams are running simultaneously and make a concurrent call.

Amongst the solutions:
- wait for a bit
- change IP (out of scope for the tap)

This PR implements a 61 seconds wait and retry signal