### PR TITLE
Fix broken state messaging in sdk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -639,45 +639,36 @@ python-versions = ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "singer-sdk"
-version = "0.13.1"
+version = "0.14.0"
 description = "A framework for building Singer taps"
 category = "main"
 optional = false
-python-versions = "<3.12,>=3.7.1"
-develop = false
+python-versions = ">=3.7.1,<3.12"
 
 [package.dependencies]
 backoff = ">=2.0.0,<3.0"
-click = "~=8.0"
+click = ">=8.0,<9.0"
 cryptography = ">=3.4.6,<39.0.0"
-fs = "^2.4.16"
+fs = ">=2.4.16,<3.0.0"
 importlib-metadata = {version = "<5.0.0", markers = "python_version < \"3.8\""}
 importlib-resources = {version = "5.9.0", markers = "python_version < \"3.9\""}
-inflection = "^0.5.1"
-joblib = "^1.0.1"
-jsonpath-ng = "^1.5.3"
-jsonschema = "^4.16.0"
+inflection = ">=0.5.1,<0.6.0"
+joblib = ">=1.0.1,<2.0.0"
+jsonpath-ng = ">=1.5.3,<2.0.0"
+jsonschema = ">=4.16.0,<5.0.0"
 memoization = ">=0.3.2,<0.5.0"
-pendulum = "^2.1.0"
-PyJWT = "~=2.4"
+pendulum = ">=2.1.0,<3.0.0"
+PyJWT = ">=2.4,<3.0"
 python-dotenv = ">=0.20,<0.22"
-pytz = "^2022.2.1"
-PyYAML = "^6.0"
-requests = "^2.25.1"
-simplejson = "^3.17.6"
-sqlalchemy = "^1.4"
-typing-extensions = "^4.2.0"
+pytz = ">=2022.2.1,<2023.0.0"
+PyYAML = ">=6.0,<7.0"
+requests = ">=2.25.1,<3.0.0"
+simplejson = ">=3.17.6,<4.0.0"
+sqlalchemy = ">=1.4,<2.0"
+typing-extensions = ">=4.2.0,<5.0.0"
 
 [package.extras]
-debugging = []
 docs = ["myst-parser (>=0.17.2,<0.19.0)", "sphinx (>=4.5,<6.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)", "sphinx-rtd-theme (>=0.5.2,<1.2.0)"]
-samples = []
-
-[package.source]
-type = "git"
-url = "https://github.com/meltano/sdk"
-reference = "eb6e7a7376cd38f882f106158bdbae7dda900771"
-resolved_reference = "eb6e7a7376cd38f882f106158bdbae7dda900771"
 
 [[package]]
 name = "six"
@@ -834,7 +825,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "<3.12,>=3.7.2"
-content-hash = "09c16eabe185604ed973a6c2acb7a2618bf3d866fac55100afb4b9d1ae25e8f9"
+content-hash = "629f2b240a5e2e3dc93908f5bba220fd4f9c7a1ebb49f25440807fafcbc8fb93"
 
 [metadata.files]
 appdirs = [
@@ -1044,6 +1035,7 @@ greenlet = [
     {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5b0ff9878333823226d270417f24f4d06f235cb3e54d1103b71ea537a6a86ce"},
     {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be9e0fb2ada7e5124f5282d6381903183ecc73ea019568d6d63d33f25b2a9000"},
     {file = "greenlet-2.0.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b493db84d124805865adc587532ebad30efa68f79ad68f11b336e0a51ec86c2"},
+    {file = "greenlet-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0459d94f73265744fee4c2d5ec44c6f34aa8a31017e6e9de770f7bcf29710be9"},
     {file = "greenlet-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a20d33124935d27b80e6fdacbd34205732660e0a1d35d8b10b3328179a2b51a1"},
     {file = "greenlet-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:ea688d11707d30e212e0110a1aac7f7f3f542a259235d396f88be68b649e47d1"},
     {file = "greenlet-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:afe07421c969e259e9403c3bb658968702bc3b78ec0b6fde3ae1e73440529c23"},
@@ -1052,6 +1044,7 @@ greenlet = [
     {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:659f167f419a4609bc0516fb18ea69ed39dbb25594934bd2dd4d0401660e8a1e"},
     {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:356e4519d4dfa766d50ecc498544b44c0249b6de66426041d7f8b751de4d6b48"},
     {file = "greenlet-2.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:811e1d37d60b47cb8126e0a929b58c046251f28117cb16fcd371eed61f66b764"},
+    {file = "greenlet-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:d38ffd0e81ba8ef347d2be0772e899c289b59ff150ebbbbe05dc61b1246eb4e0"},
     {file = "greenlet-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0109af1138afbfb8ae647e31a2b1ab030f58b21dd8528c27beaeb0093b7938a9"},
     {file = "greenlet-2.0.1-cp38-cp38-win32.whl", hash = "sha256:88c8d517e78acdf7df8a2134a3c4b964415b575d2840a2746ddb1cc6175f8608"},
     {file = "greenlet-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:d6ee1aa7ab36475035eb48c01efae87d37936a8173fc4d7b10bb02c2d75dd8f6"},
@@ -1060,6 +1053,7 @@ greenlet = [
     {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:505138d4fa69462447a562a7c2ef723c6025ba12ac04478bc1ce2fcc279a2db5"},
     {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cce1e90dd302f45716a7715517c6aa0468af0bf38e814ad4eab58e88fc09f7f7"},
     {file = "greenlet-2.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e9744c657d896c7b580455e739899e492a4a452e2dd4d2b3e459f6b244a638d"},
+    {file = "greenlet-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:662e8f7cad915ba75d8017b3e601afc01ef20deeeabf281bd00369de196d7726"},
     {file = "greenlet-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:41b825d65f31e394b523c84db84f9383a2f7eefc13d987f308f4663794d2687e"},
     {file = "greenlet-2.0.1-cp39-cp39-win32.whl", hash = "sha256:db38f80540083ea33bdab614a9d28bcec4b54daa5aff1668d7827a9fc769ae0a"},
     {file = "greenlet-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:b23d2a46d53210b498e5b701a1913697671988f4bf8e10f935433f6e7c332fb6"},
@@ -1370,7 +1364,10 @@ simplejson = [
     {file = "simplejson-3.17.6-cp39-cp39-win_amd64.whl", hash = "sha256:3fe87570168b2ae018391e2b43fbf66e8593a86feccb4b0500d134c998983ccc"},
     {file = "simplejson-3.17.6.tar.gz", hash = "sha256:cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6"},
 ]
-singer-sdk = []
+singer-sdk = [
+    {file = "singer_sdk-0.14.0-py3-none-any.whl", hash = "sha256:634802ed4e9c71e9ade4bb772f4b2f1510b2cb971957f96a163fb592560a5cd8"},
+    {file = "singer_sdk-0.14.0.tar.gz", hash = "sha256:c69b670f5202e833db3c5ecac68dabb280f6cdaa645a55c2a5dce256554eddb0"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -643,32 +643,41 @@ version = "0.13.1"
 description = "A framework for building Singer taps"
 category = "main"
 optional = false
-python-versions = ">=3.7.1,<3.12"
+python-versions = "<3.12,>=3.7.1"
+develop = false
 
 [package.dependencies]
 backoff = ">=2.0.0,<3.0"
-click = ">=8.0,<9.0"
+click = "~=8.0"
 cryptography = ">=3.4.6,<39.0.0"
-fs = ">=2.4.16,<3.0.0"
+fs = "^2.4.16"
 importlib-metadata = {version = "<5.0.0", markers = "python_version < \"3.8\""}
 importlib-resources = {version = "5.9.0", markers = "python_version < \"3.9\""}
-inflection = ">=0.5.1,<0.6.0"
-joblib = ">=1.0.1,<2.0.0"
-jsonpath-ng = ">=1.5.3,<2.0.0"
-jsonschema = ">=4.16.0,<5.0.0"
+inflection = "^0.5.1"
+joblib = "^1.0.1"
+jsonpath-ng = "^1.5.3"
+jsonschema = "^4.16.0"
 memoization = ">=0.3.2,<0.5.0"
-pendulum = ">=2.1.0,<3.0.0"
-PyJWT = ">=2.4,<3.0"
+pendulum = "^2.1.0"
+PyJWT = "~=2.4"
 python-dotenv = ">=0.20,<0.22"
-pytz = ">=2022.2.1,<2023.0.0"
-PyYAML = ">=6.0,<7.0"
-requests = ">=2.25.1,<3.0.0"
-simplejson = ">=3.17.6,<4.0.0"
-sqlalchemy = ">=1.4,<2.0"
-typing-extensions = ">=4.2.0,<5.0.0"
+pytz = "^2022.2.1"
+PyYAML = "^6.0"
+requests = "^2.25.1"
+simplejson = "^3.17.6"
+sqlalchemy = "^1.4"
+typing-extensions = "^4.2.0"
 
 [package.extras]
-docs = ["myst-parser (>=0.17.2,<0.19.0)", "sphinx (>=4.5,<6.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)", "sphinx-rtd-theme (>=0.5.2,<1.1.0)"]
+debugging = []
+docs = ["myst-parser (>=0.17.2,<0.19.0)", "sphinx (>=4.5,<6.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)", "sphinx-rtd-theme (>=0.5.2,<1.2.0)"]
+samples = []
+
+[package.source]
+type = "git"
+url = "https://github.com/meltano/sdk"
+reference = "eb6e7a7376cd38f882f106158bdbae7dda900771"
+resolved_reference = "eb6e7a7376cd38f882f106158bdbae7dda900771"
 
 [[package]]
 name = "six"
@@ -737,7 +746,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "types-beautifulsoup4"
-version = "4.11.6"
+version = "4.11.6.1"
 description = "Typing stubs for beautifulsoup4"
 category = "dev"
 optional = false
@@ -745,7 +754,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.8.19.2"
+version = "2.8.19.3"
 description = "Typing stubs for python-dateutil"
 category = "main"
 optional = false
@@ -753,7 +762,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.28.11.2"
+version = "2.28.11.4"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -764,7 +773,7 @@ types-urllib3 = "<1.27"
 
 [[package]]
 name = "types-simplejson"
-version = "3.17.7.1"
+version = "3.17.7.2"
 description = "Typing stubs for simplejson"
 category = "main"
 optional = false
@@ -772,7 +781,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.25.1"
+version = "1.26.25.3"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -825,7 +834,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "<3.12,>=3.7.2"
-content-hash = "4edb4de509d11e6e2c91dac2d3ab67f59b56d5ebc54be261af37e68fa80c4187"
+content-hash = "09c16eabe185604ed973a6c2acb7a2618bf3d866fac55100afb4b9d1ae25e8f9"
 
 [metadata.files]
 appdirs = [
@@ -1361,10 +1370,7 @@ simplejson = [
     {file = "simplejson-3.17.6-cp39-cp39-win_amd64.whl", hash = "sha256:3fe87570168b2ae018391e2b43fbf66e8593a86feccb4b0500d134c998983ccc"},
     {file = "simplejson-3.17.6.tar.gz", hash = "sha256:cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6"},
 ]
-singer-sdk = [
-    {file = "singer_sdk-0.13.1-py3-none-any.whl", hash = "sha256:13c651affc15c82743dfb6b7eddfc2bb487d2bd786ec98b3349174444fc2856d"},
-    {file = "singer_sdk-0.13.1.tar.gz", hash = "sha256:b9636843c78de3954e064ec52cb8269950a0c099bdd4c4b96011e16e28f4ca2e"},
-]
+singer-sdk = []
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1447,24 +1453,24 @@ typed-ast = [
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
 ]
 types-beautifulsoup4 = [
-    {file = "types-beautifulsoup4-4.11.6.tar.gz", hash = "sha256:2670dd71995df464041e2941fa9bbb694795271e3dedd7262b4766649a1cbe82"},
-    {file = "types_beautifulsoup4-4.11.6-py3-none-any.whl", hash = "sha256:ac9dd1383481201ea07f27c5a43e7b1ee71caf9c720b7ae951db15d60d126e80"},
+    {file = "types-beautifulsoup4-4.11.6.1.tar.gz", hash = "sha256:d46be8f409ddccb6daaa9d118484185e70bcf552085c39c6d05b157cd1462e04"},
+    {file = "types_beautifulsoup4-4.11.6.1-py3-none-any.whl", hash = "sha256:c1f803367a2b07ad4fdac40ddbea557010dc4ddd1ee92d801f317eb02e2e3c72"},
 ]
 types-python-dateutil = [
-    {file = "types-python-dateutil-2.8.19.2.tar.gz", hash = "sha256:e6e32ce18f37765b08c46622287bc8d8136dc0c562d9ad5b8fd158c59963d7a7"},
-    {file = "types_python_dateutil-2.8.19.2-py3-none-any.whl", hash = "sha256:3f4dbe465e7e0c6581db11fd7a4855d1355b78712b3f292bd399cd332247e9c0"},
+    {file = "types-python-dateutil-2.8.19.3.tar.gz", hash = "sha256:a313284df5ed3fd078303262edc0efde28998cd08e5061ef1ccc0bb5fef4d2da"},
+    {file = "types_python_dateutil-2.8.19.3-py3-none-any.whl", hash = "sha256:ce6af1bdf0aca6b7dc8815a664f0e8b55da91ff7851102cf87c87178e7c8e7ec"},
 ]
 types-requests = [
-    {file = "types-requests-2.28.11.2.tar.gz", hash = "sha256:fdcd7bd148139fb8eef72cf4a41ac7273872cad9e6ada14b11ff5dfdeee60ed3"},
-    {file = "types_requests-2.28.11.2-py3-none-any.whl", hash = "sha256:14941f8023a80b16441b3b46caffcbfce5265fd14555844d6029697824b5a2ef"},
+    {file = "types-requests-2.28.11.4.tar.gz", hash = "sha256:d4f342b0df432262e9e326d17638eeae96a5881e78e7a6aae46d33870d73952e"},
+    {file = "types_requests-2.28.11.4-py3-none-any.whl", hash = "sha256:bdb1f9811e53d0642c8347b09137363eb25e1a516819e190da187c29595a1df3"},
 ]
 types-simplejson = [
-    {file = "types-simplejson-3.17.7.1.tar.gz", hash = "sha256:cf490006a775972f15b9524f4838f8557d4609d68e4d4a214b33f0a87830cc19"},
-    {file = "types_simplejson-3.17.7.1-py3-none-any.whl", hash = "sha256:5860a7d88e966f678408489bfb3c5fbf814350afc290292817e6af11c5ba200a"},
+    {file = "types-simplejson-3.17.7.2.tar.gz", hash = "sha256:a4968032706c4460e7fbe6ba66c5744ae7c9b94afd7c0abead7d54ab3fa67127"},
+    {file = "types_simplejson-3.17.7.2-py3-none-any.whl", hash = "sha256:ee1a49ed92b92a7adeaabb3413b71bad3623fb731791c5614db763ce9f195725"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.25.1.tar.gz", hash = "sha256:a948584944b2412c9a74b9cf64f6c48caf8652cb88b38361316f6d15d8a184cd"},
-    {file = "types_urllib3-1.26.25.1-py3-none-any.whl", hash = "sha256:f6422596cc9ee5fdf68f9d547f541096a20c2dcfd587e37c804c9ea720bf5cb2"},
+    {file = "types-urllib3-1.26.25.3.tar.gz", hash = "sha256:1807b87b8ee1ae0226813ba2c52330eff20fb2bf6359b1de24df08eb3090e442"},
+    {file = "types_urllib3-1.26.25.3-py3-none-any.whl", hash = "sha256:a188c24fc61a99658c8c324c8dd7419f5b91a0d89df004e5f576869122c1db55"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,7 @@ python = "<3.12,>=3.7.2"
 requests = "^2.28.1"
 # For local SDK dev:
 # singer-sdk = {path = "../singer-sdk", develop = true}
-# singer-sdk = "^0.13.1"
-singer-sdk = {git = "https://github.com/meltano/sdk", rev = "eb6e7a7376cd38f882f106158bdbae7dda900771"}
+singer-sdk = "^0.14.0"
 types-simplejson = "^3.17.2"
 types-python-dateutil = "^2.8.6"
 nested-lookup = "^0.2.23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ python = "<3.12,>=3.7.2"
 requests = "^2.28.1"
 # For local SDK dev:
 # singer-sdk = {path = "../singer-sdk", develop = true}
-singer-sdk = "^0.13.1"
+# singer-sdk = "^0.13.1"
+singer-sdk = {git = "https://github.com/meltano/sdk", rev = "eb6e7a7376cd38f882f106158bdbae7dda900771"}
 types-simplejson = "^3.17.2"
 types-python-dateutil = "^2.8.6"
 nested-lookup = "^0.2.23"

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -1,7 +1,7 @@
-import datetime
 import json
 import os
 import re
+from dateutil.parser import isoparse
 from typing import Optional
 from unittest.mock import patch
 
@@ -122,16 +122,14 @@ def test_last_state_message_is_valid(capsys, repo_list_config):
     assert "progress_markers" not in last_state_msg
 
     last_state = json.loads(last_state_msg)
-    last_state_updated_at = datetime.datetime.fromisoformat(
+    last_state_updated_at = isoparse(
         last_state["value"]["bookmarks"]["issue_comments"]["partitions"][0][
             "replication_key_value"
         ]
     )
     latest_updated_at = max(
         map(
-            lambda record: datetime.datetime.fromisoformat(
-                json.loads(record)["record"]["updated_at"]
-            ),
+            lambda record: isoparse(json.loads(record)["record"]["updated_at"]),
             issue_comments_records,
         )
     )

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -1,11 +1,11 @@
 import json
 import os
 import re
-from dateutil.parser import isoparse
 from typing import Optional
 from unittest.mock import patch
 
 import pytest
+from dateutil.parser import isoparse
 from singer_sdk._singerlib import Catalog
 from singer_sdk.helpers import _catalog as cat_helpers
 

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -1,5 +1,7 @@
-import logging
+import datetime
+import json
 import os
+import re
 from typing import Optional
 from unittest.mock import patch
 
@@ -97,6 +99,43 @@ def test_get_a_repository_in_repo_list_mode(
     # check that the tap corrects invalid case in config input
     assert '"repo": "Tap-GitLab"' not in captured_out
     assert '"org": "meltanolabs"' not in captured_out
+
+
+@pytest.mark.repo_list(["MeltanoLabs/tap-github"])
+def test_last_state_message_is_valid(capsys, repo_list_config):
+    """
+    Validate that the last state message is not a temporary one and contains the
+    expected values for a stream with overridden state partitioning keys.
+    Run this on a single repo to avoid having to filter messages too much.
+    """
+    repo_list_config["skip_parent_streams"] = True
+    captured_out = run_tap_with_config(capsys, repo_list_config, "repositories")
+    # capture the messages we're interested in
+    state_messages = re.findall(r'{"type": "STATE", "value":.*}', captured_out)
+    issue_comments_records = re.findall(
+        r'{"type": "RECORD", "stream": "issue_comments",.*}', captured_out
+    )
+    assert state_messages is not None
+    last_state_msg = state_messages[-1]
+
+    # make sure we don't have a temporary state message at the very end
+    assert "progress_markers" not in last_state_msg
+
+    last_state = json.loads(last_state_msg)
+    last_state_updated_at = datetime.datetime.fromisoformat(
+        last_state["value"]["bookmarks"]["issue_comments"]["partitions"][0][
+            "replication_key_value"
+        ]
+    )
+    latest_updated_at = max(
+        map(
+            lambda record: datetime.datetime.fromisoformat(
+                json.loads(record)["record"]["updated_at"]
+            ),
+            issue_comments_records,
+        )
+    )
+    assert last_state_updated_at == latest_updated_at
 
 
 # case is incorrect on purpose, so we can check that the tap corrects it


### PR DESCRIPTION
This PR updates the sdk to fix a bug in state messaging from the tap which prevented certain streams (such `issue_comments`) from ending with a valid state message, making it impossible to actually run them incrementally.