### PR TITLE
Fix graphql pagination

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -355,9 +355,14 @@ class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
         # Get deepest pagination item
         max_pagination_index = max(has_next_page_indices)
 
-        # We leverage previous_token to remember the pagination cursors for other indices.
+        # We leverage previous_token to remember the pagination cursors
+        # for indices below max_pagination_index.
         next_page_cursors: Dict[str, str] = dict()
-        next_page_cursors.update(previous_token or {})
+        for (key, value) in (previous_token or {}).items():
+            # Only keep pagination info for indices below max_pagination_index.
+            pagination_index = int(str(key).split("_")[1])
+            if pagination_index < max_pagination_index:
+                next_page_cursors[key] = value
 
         # Get the pagination cursor to update and increment it.
         next_page_end_cursor_results = nested_lookup(

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -382,7 +382,7 @@ class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
         self, context: Optional[Dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
-        params = context.copy() or dict()
+        params = context.copy() if context else dict()
         params["per_page"] = self.MAX_PER_PAGE
         if next_page_token:
             params.update(next_page_token)

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -365,8 +365,11 @@ class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
             document=resp_json,
         )
 
-        next_page_key = f"nextPageCursor_{pagination_index}"
-        next_page_cursors[next_page_key] = next_page_end_cursor_results[0]
+        next_page_key = f"nextPageCursor_{max_pagination_index}"
+        next_page_cursor = next(
+            cursor for cursor in next_page_end_cursor_results if cursor is not None
+        )
+        next_page_cursors[next_page_key] = next_page_cursor
 
         return next_page_cursors
 

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -382,7 +382,7 @@ class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
         self, context: Optional[Dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
-        params = context or dict()
+        params = context.copy() or dict()
         params["per_page"] = self.MAX_PER_PAGE
         if next_page_token:
             params.update(next_page_token)

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -2079,10 +2079,11 @@ class DependenciesStream(GitHubGraphqlStream):
     def query(self) -> str:
         """Return dynamic GraphQL query."""
         # Graphql id is equivalent to REST node_id. To keep the tap consistent, we rename "id" to "node_id".
+        # Due to GrapQl nested-pagination limitations, we loop through the top level dependencyGraphManifests one by one.
         return """
           query repositoryDependencies($repo: String! $org: String! $nextPageCursor_0: String $nextPageCursor_1: String) {
             repository(name: $repo owner: $org) {
-              dependencyGraphManifests (first: 10 withDependencies: true after: $nextPageCursor_0) {
+              dependencyGraphManifests (first: 1 withDependencies: true after: $nextPageCursor_0) {
                 totalCount
                 pageInfo {
                   hasNextPage_0: hasNextPage


### PR DESCRIPTION
Fixes #165 by iterating through pagination cursors with the same index if the first ones are null, and making sure that we properly reset pagination cursor for higher indices