### PR TITLE
Update CI caching action

### DIFF
--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v3
       with:
         # must match the path in tests/__init__.py
-        path: 'api_calls_tests_cache.sqlite'
+        path: '.cache/api_calls_tests_cache.sqlite'
         # github cache expires after 1wk, and we expire the content after 24h
         # this key should not need to change unless we need to clear the cache
         key: api-cache-v3

--- a/.github/workflows/test_tap.yml
+++ b/.github/workflows/test_tap.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Cache github API responses
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v3
       with:
         # must match the path in tests/__init__.py
         path: 'api_calls_tests_cache.sqlite'
@@ -47,7 +47,7 @@ jobs:
         virtualenvs-in-project: true
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: .venv
         key: venv-3-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
-api_calls_tests_cache.sqlite
 
 # Translations
 *.mo

--- a/tap_github/tests/__init__.py
+++ b/tap_github/tests/__init__.py
@@ -8,7 +8,7 @@ import requests_cache
 # To clear the cache, just delete the sqlite db file at api_calls_tests_cache.sqlite
 # in the root of this repository
 requests_cache.install_cache(
-    "api_calls_tests_cache",
+    ".cache/api_calls_tests_cache",
     backend="sqlite",
     # make sure that API keys don't end up being cached
     # Also ignore user-agent so that various versions of request


### PR DESCRIPTION
This might fix a bug in the action, from https://github.com/marketplace/actions/cache#v3:

> Fixed cache not working with github workspace directory or current directory.

Which might explain why the venv is cached, but not the api requests file?