### PR TITLE
fix: use `datetime` type for fetched_at

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -2032,7 +2032,7 @@ class ExtraMetricsStream(GitHubRestStream):
         th.Property("open_prs", th.IntegerType),
         th.Property("dependents", th.IntegerType),
         th.Property("contributors", th.IntegerType),
-        th.Property("fetched_at", th.DateType),
+        th.Property("fetched_at", th.DateTimeType),
     ).to_dict()
 
 


### PR DESCRIPTION
Reported in slack:

https://meltano.slack.com/archives/CMN8HELB0/p1673621544959589?thread_ts=1673611200.162959&cid=CMN8HELB0