### PR TITLE
fix: Use an aware timestamp in UTC timezone

### DIFF
--- a/tap_github/scraping.py
+++ b/tap_github/scraping.py
@@ -5,7 +5,7 @@ Inspired by https://github.com/dogsheep/github-to-sqlite/pull/70
 import logging
 import re
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, Optional, Union, cast
 from urllib.parse import urlparse
 
@@ -139,7 +139,7 @@ def scrape_metrics(
         logger,
     )
 
-    fetched_at = datetime.now()
+    fetched_at = datetime.now(tz=timezone.utc)
 
     metrics = [
         {


### PR DESCRIPTION
This PR fixes a small bug in the `ExtraMetrics` stream which was using a *local* timestamp, instead of UTC ones used everywhere.
Running the tap in the `UTC+1` where I'm at right now led to a broken record like this (formatting added for readability):
```python
{'type': 'RECORD',
 'stream': 'extra-metrics',
 'record': {'open_issues': 101,
	 'open_prs': 15,
	 'dependents': 0,
	 'contributors': 20,
	 'fetched_at': '2023-02-09T12:37:27.508297+00:00',
	 'repo': 'mapswipe',
	 'org': 'mapswipe',
	 'repo_id': 68943183},
 'time_extracted': '2023-02-09T11:37:27.508573+00:00',
 '__raw_line_size': 295})])
```

Note how the timestamps differ by 1h, with `fetched_at` appearing to be in the future at the time of processing this record.
The PR makes these timestamps equal.