### PR TITLE
fix: Prevent crash during cost calculation

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -405,12 +405,10 @@ class GitHubGraphqlStream(GraphQLStream, GitHubRestStream):
     ) -> Dict[str, int]:
         """Return the cost of the last graphql API call."""
         costgen = extract_jsonpath("$.data.rateLimit.cost", input=response.json())
-        try:
-            cost = next(costgen)
-        except StopIteration:
-            # calculate_sync_cost is called before the main response parsing.
-            # In some cases, the tap crashes here before we have been able to
-            # properly analyze where the error comes from, so we ignore these
-            # costs to allow figuring out what happened downstream.
-            cost = 0
+        # calculate_sync_cost is called before the main response parsing.
+        # In some cases, the tap crashes here before we have been able to
+        # properly analyze where the error comes from, so we ignore these
+        # costs to allow figuring out what happened downstream, by setting
+        # them to 0.
+        cost = next(costgen, 0)
         return {"rest": 0, "graphql": int(cost), "search": 0}


### PR DESCRIPTION
This PR fixes a small bug in the cost calculation logic which caused the tap to crash in some cases for lack of the expected key in the server's response.

As the sdk calculates costs before iterating through records, where the main error handling logic lives, it would sometimes never reach that logic. This change prevents this and makes sure that the main error logic is reached, at the expense of "proper" cost calculation.