### PR TITLE
fix: Raise an api error on graphql errors

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -99,15 +99,13 @@ class RepositoryStream(GitHubRestStream):
                 as we actually expect these in this stream when we send an invalid
                 repo name.
                 """
-                GitHubRestStream.validate_response(self, response)
-                rj = response.json()
-                if "errors" in rj:
-                    # simplify error handling by looking at the first error only
-                    err = rj["errors"][0]
-                    if err.get("type") != "NOT_FOUND":
-                        raise FatalAPIError(f"Graphql error: {err}", response)
+                try:
+                    super().validate_response(response)
+                except FatalAPIError as e:
+                    if "NOT_FOUND" in str(e):
+                        return
+                    raise
 
-        repos_with_ids: list = list()
         temp_stream = TempStream(self._tap, list(repo_list))
         # replace manually provided org/repo values by the ones obtained
         # from github api. This guarantees that case is correct in the output data.

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -106,6 +106,8 @@ class RepositoryStream(GitHubRestStream):
                         return
                     raise
 
+        repos_with_ids: list = list()
+
         temp_stream = TempStream(self._tap, list(repo_list))
         # replace manually provided org/repo values by the ones obtained
         # from github api. This guarantees that case is correct in the output data.

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -6,6 +6,7 @@ from urllib.parse import parse_qs, urlparse
 import requests
 from dateutil.parser import parse
 from singer_sdk import typing as th  # JSON Schema typing helpers
+from singer_sdk.exceptions import FatalAPIError
 from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 from tap_github.client import GitHubGraphqlStream, GitHubRestStream

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -107,7 +107,6 @@ class RepositoryStream(GitHubRestStream):
                     raise
 
         repos_with_ids: list = list()
-
         temp_stream = TempStream(self._tap, list(repo_list))
         # replace manually provided org/repo values by the ones obtained
         # from github api. This guarantees that case is correct in the output data.

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -19,6 +19,10 @@ repo_list_2 = [
     "MeltanoLabs/Tap-GitLab",
     # mistype the org
     "meltanolabs/target-athena",
+    # a repo that does not exist at all
+    # this one has no matching record below as it should be removed
+    # from the list by the TempStream
+    "brokenOrg/does_not_exist",
 ]
 # the same list, but without typos, for validation
 repo_list_2_corrected = [

--- a/tap_github/tests/test_tap.py
+++ b/tap_github/tests/test_tap.py
@@ -98,7 +98,7 @@ def test_get_a_repository_in_repo_list_mode(
     # Verify we got the right number of records
     # one per repo in the list only if we sync the "repositories" stream, 0 if not
     assert captured_out.count('{"type": "RECORD", "stream": "repositories"') == len(
-        repo_list_2 * (not skip_parent_streams)
+        repo_list_2_ids * (not skip_parent_streams)
     )
     # check that the tap corrects invalid case in config input
     assert '"repo": "Tap-GitLab"' not in captured_out


### PR DESCRIPTION
The tap (and the sdk) were not reporting any graphql errors (because annoyingly, graphql chooses to ignore good HTTP practice by returning a status 200 even on fatal errors).

This PR adds a minimal level of reporting by checking for `errors` in the response.

@edgarrmondragon The sdk does not seem to check for graphql errors at all, it simply defers to the REST streams `validate_response` which is not adapted to it. Is it worth adding something in the `sdk` in that respect?