### PR TITLE
fix: adding pull_number field to 'pull_request_commits'

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1346,6 +1346,10 @@ class PullRequestCommits(GitHubRestStream):
         ),
     ).to_dict()
 
+    def post_process(self, row: dict, context: Optional[Dict[str, str]] = None) -> dict:
+        if context is not None and "pull_number" in context:
+            row["pull_number"] = context["pull_number"]
+        return row
 
 class ReviewsStream(GitHubRestStream):
     name = "reviews"

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1351,6 +1351,7 @@ class PullRequestCommits(GitHubRestStream):
             row["pull_number"] = context["pull_number"]
         return row
 
+
 class ReviewsStream(GitHubRestStream):
     name = "reviews"
     path = "/repos/{org}/{repo}/pulls/{pull_number}/reviews"


### PR DESCRIPTION
Fix issue #183 by adding pull_number field to the 'pull_request_commits' stream.