### PR TITLE
fix: Set MAX_RESULTS_LIMIT for Releases stream

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -640,6 +640,8 @@ class ReleasesStream(GitHubRestStream):
     state_partitioning_keys = ["repo", "org"]
     replication_key = "published_at"
 
+    MAX_RESULTS_LIMIT = 10000
+
     schema = th.PropertiesList(
         # Parent keys
         th.Property("repo", th.StringType),


### PR DESCRIPTION
Fix #182 by seting MAX_RESULTS_LIMIT for Releases stream.