### PR TITLE
feat: Refresh app tokens

### DIFF
--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -211,7 +211,7 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
         self.active_token: Optional[TokenRateLimit] = (
             choice(list(self.tokens_map.values())) if len(self.tokens_map) else None
         )
-        self.last_private_key_token_refresh: datetime = None
+        self.last_private_key_token_refresh = None
         # Refresh tokens from private key if it was supplied
         if self.active_token is None:
             self.active_token = self.refresh_app_token()

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -113,6 +113,8 @@ def generate_app_access_token(
 class GitHubTokenAuthenticator(APIAuthenticatorBase):
     """Base class for offloading API auth."""
 
+    last_private_key_token_refresh: Optional[datetime]
+
     def refresh_app_token(self):
         if self.last_private_key_token_refresh:
             # Do not refresh token if less than 10 minutes have passed, if this is requested the app probably hit its rate limit.


### PR DESCRIPTION
When running long initial syncs using Github app private keys, the tokens expire in 1 hour, which makes the process fail after this timespan. This PR separates the app tokens into a new function `refresh_app_token` that can get called again in `get_next_auth_token`, i've tested it for my use case and it no longer fails after 1 hour.