### PR TITLE
fix: If a member is part of multiple teams, they will only be listed once

### DIFF
--- a/tap_github/organization_streams.py
+++ b/tap_github/organization_streams.py
@@ -123,7 +123,7 @@ class TeamMembersStream(GitHubRestStream):
     """
 
     name = "team_members"
-    primary_keys = ["id"]
+    primary_keys = ["id", "team_slug"]
     path = "/orgs/{org}/teams/{team_slug}/members"
     ignore_parent_replication_key = True
     parent_stream_type = TeamsStream


### PR DESCRIPTION
Fixes #190 