### PR TITLE
fix: update html parser to work on very high values like 5k+

### DIFF
--- a/tap_github/scraping.py
+++ b/tap_github/scraping.py
@@ -126,10 +126,8 @@ def scrape_metrics(
     soup = BeautifulSoup(response.content, "html.parser")
 
     try:
-        issues = parse_counter(soup.find("span", id="issues-repo-tab-count"), logger)
-        prs = parse_counter(
-            soup.find("span", id="pull-requests-repo-tab-count"), logger
-        )
+        issues = parse_counter(soup.find("span", id="issues-repo-tab-count"))
+        prs = parse_counter(soup.find("span", id="pull-requests-repo-tab-count"))
     except IndexError:
         # These two items should exist. We raise an error if we could not find them.
         raise IndexError(
@@ -143,9 +141,7 @@ def scrape_metrics(
     dependents: int = 0
     if dependents_node_parent is not None:
         if dependents_node_parent["href"].endswith("/network/dependents"):
-            dependents = parse_counter(
-                getattr(dependents_node, "next_element", None), logger
-            )
+            dependents = parse_counter(getattr(dependents_node, "next_element", None))
 
     # likewise, handle edge cases with contributors
     contributors_node = soup.find(text=contributors_regex)
@@ -155,7 +151,6 @@ def scrape_metrics(
         if contributors_node_parent["href"].endswith("/graphs/contributors"):
             contributors = parse_counter(
                 getattr(contributors_node, "next_element", None),
-                logger,
             )
 
     fetched_at = datetime.now(tz=timezone.utc)

--- a/tap_github/scraping.py
+++ b/tap_github/scraping.py
@@ -93,9 +93,12 @@ def _scrape_dependents(url: str, logger: logging.Logger) -> Iterable[Dict[str, A
             url = ""
 
 
-def parse_counter(
-    tag: Union[Tag, NavigableString, None], logger: logging.Logger
-) -> int:
+def parse_counter(tag: Union[Tag, NavigableString, None]) -> int:
+    """
+    Extract a count of [issues|PR|contributors...] from an HTML tag.
+    For very high numbers, we only get an approximate value as github
+    does not provide the actual number.
+    """
     if not tag:
         return 0
     try:
@@ -106,8 +109,8 @@ def parse_counter(
             title_string = cast(str, title)
         else:
             title_string = cast(str, title[0])
-        return int(title_string.strip().replace(",", ""))
-    except KeyError:
+        return int(title_string.strip().replace(",", "").replace("+", ""))
+    except (KeyError, ValueError):
         raise IndexError(
             f"Could not parse counter {tag}. Maybe the GitHub page format has changed?"
         )


### PR DESCRIPTION
Partially addresses #205 by avoiding a crash on high values.
The downside is that we don't get the real value from the HTML content as github does not provide it.

See the linked ticket for more details.