### PR TITLE
fix: chunk user list when enriching with ids to avoid timeouts

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -85,8 +85,6 @@ class RepositoryStream(GitHubRestStream):
             @property
             def query(self) -> str:
                 chunks = list()
-                # there is probably some limit to how many items can be requested
-                # in a single query, but it's well above 1k.
                 for i, repo in enumerate(self.repo_list):
                     chunks.append(
                         f'repo{i}: repository(name: "{repo[1]}", owner: "{repo[0]}") '

--- a/tap_github/user_streams.py
+++ b/tap_github/user_streams.py
@@ -80,8 +80,6 @@ class UserStream(GitHubRestStream):
             @property
             def query(self) -> str:
                 chunks = list()
-                # there is probably some limit to how many items can be requested
-                # in a single query, but it's well above 1k.
                 for i, user in enumerate(self.user_list):
                     # we use the `repositoryOwner` query which is the only one that
                     # works on both users and orgs with graphql. REST is less picky
@@ -291,7 +289,8 @@ class UserContributedToStream(GitHubGraphqlStream):
     @property
     def query(self) -> str:
         """Return dynamic GraphQL query."""
-        # Graphql id is equivalent to REST node_id. To keep the tap consistent, we rename "id" to "node_id".
+        # Graphql id is equivalent to REST node_id. To keep the tap consistent,
+        # we rename "id" to "node_id".
         return """
           query userContributedTo($username: String! $nextPageCursor_0: String) {
             user (login: $username) {

--- a/tap_github/user_streams.py
+++ b/tap_github/user_streams.py
@@ -36,14 +36,12 @@ class UserStream(GitHubRestStream):
             # seems closer to 1000, use half that to stay safe.
             chunk_size = 500
             list_length = len(input_user_list)
-            self.logger.info(f"Filtering repository list of {list_length} repositories")
+            self.logger.info(f"Filtering user list of {list_length} users")
             for ndx in range(0, list_length, chunk_size):
                 augmented_user_list += self.get_repo_ids(
                     input_user_list[ndx : ndx + chunk_size]
                 )
-            self.logger.info(
-                f"Running the tap on {len(augmented_user_list)} repositories"
-            )
+            self.logger.info(f"Running the tap on {len(augmented_user_list)} users")
             return augmented_user_list
 
         elif "user_ids" in self.config:


### PR DESCRIPTION
This PR adapts #203 to the user stream to avoid timeouts on graphql queries with many (over 1k?) usernames passed as config.

And a bit of cleanup in comments :broom: 