### PR TITLE
fix: check that exc.response is not empty before accessing it

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -275,8 +275,10 @@ class GitHubRestStream(RESTStream):
             FrameType,
             cast(FrameType, cast(FrameType, inspect.currentframe()).f_back).f_back,
         ).f_locals["e"]
-        if exc.response.status_code == 403 and "rate limit exceeded" in str(
-            exc.response.content
+        if (
+            exc.response is not None
+            and exc.response.status_code == 403
+            and "rate limit exceeded" in str(exc.response.content)
         ):
             # we hit a rate limit, rotate token
             prepared_request = details["args"][0]


### PR DESCRIPTION
Github's API sometimes returns an empty response `b''` which is not standards compliant (it's undocumented, and also not clear when/why this happens).

This triggers an exception in `urllib` and `requests` (both packages have clarified they do not intend to handle this case, it's a server-side problem):
```
requests.exceptions.ChunkedEncodingError: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", InvalidChunkLength(got length b'', 0 bytes read))
```
which bubbles up to the tap and its backoff handler. This patch just prevents the handler from crashing in such a case. It does not try to address further consequences.