### PR TITLE
chore: Update version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-github"
-version = "1.1.1"
+version = "1.3.0"
 description = "`tap-github` is Singer tap for GitHub, built with the Singer SDK."
 authors = ["Meltano and Meltano Community"]
 homepage = "https://github.com/MeltanoLabs/tap-github"


### PR DESCRIPTION
The version in pyproject.toml was out of sync with the latest release. 

I guess the bumping of this version should be part of #47.