### PR TITLE
fix: clean up control chars from issue titles as well

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -859,6 +859,8 @@ class IssuesStream(GitHubRestStream):
             # such chars are removed from the data before we pass it on to
             # the target
             row["body"] = row["body"].replace("\x00", "")
+        if row["title"] is not None:
+            row["title"] = row["title"].replace("\x00", "")
 
         # replace +1/-1 emojis to avoid downstream column name errors.
         if "reactions" in row:


### PR DESCRIPTION
Just like some issue bodies contain control char `\x00` which crashes targets like postgresql, it appears that some issue titles can cause the same problem, eg. https://github.com/cockroachdb/cockroach/issues/100343 or https://github.com/cockroachdb/cockroach/issues/100344.

This PR applies the same logic to fix the problem.