### PR TITLE
fix: prevent crash on null chars in pr titles

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1207,6 +1207,8 @@ class PullRequestsStream(GitHubRestStream):
             # such chars are removed from the data before we pass it on to
             # the target
             row["body"] = row["body"].replace("\x00", "")
+        if row["title"] is not None:
+            row["title"] = row["title"].replace("\x00", "")
 
         # replace +1/-1 emojis to avoid downstream column name errors.
         if "reactions" in row:


### PR DESCRIPTION
This PR applies the same logic to PRs as was done for issues in #232 