### PR TITLE
Add `files` to `CommitsStream`

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -11,6 +11,7 @@ from singer_sdk.helpers.jsonpath import extract_jsonpath
 
 from tap_github.client import GitHubGraphqlStream, GitHubRestStream
 from tap_github.schema_objects import (
+    files_object,
     label_object,
     milestone_object,
     reactions_object,
@@ -1105,6 +1106,7 @@ class CommitsStream(GitHubRestStream):
         ),
         th.Property("author", user_object),
         th.Property("committer", user_object),
+        th.Property("files", th.ArrayType(files_object)),
     ).to_dict()
 
 

--- a/tap_github/schema_objects.py
+++ b/tap_github/schema_objects.py
@@ -59,3 +59,17 @@ reactions_object = th.ObjectType(
     th.Property("rocket", th.IntegerType),
     th.Property("eyes", th.IntegerType),
 )
+
+files_object = th.ObjectType(
+    th.Property("sha", th.StringType),
+    th.Property("filename", th.StringType),
+    th.Property("status", th.StringType),
+    th.Property("additions", th.IntegerType),
+    th.Property("deletions", th.IntegerType),
+    th.Property("changes", th.IntegerType),
+    th.Property("blob_url", th.StringType),
+    th.Property("raw_url", th.StringType),
+    th.Property("contents_url", th.StringType),
+    th.Property("patch", th.StringType),
+    th.Property("previous_filename", th.StringType)
+)


### PR DESCRIPTION
The purpose of this PR is to add the `files` property to the `CommitsStream`.

This property contains detailed information about the changes applied to the files within a commit (e.g. `# of additions`, # of deletions`, etc), which can be relevant for analytical purposes on top of Github data.