### PR TITLE
fix: releases replication key

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -665,7 +665,7 @@ class ReleasesStream(GitHubRestStream):
     primary_keys = ["id"]
     parent_stream_type = RepositoryStream
     state_partitioning_keys = ["repo", "org"]
-    replication_key = "published_at"
+    replication_key = "created_at"
 
     MAX_RESULTS_LIMIT = 10000
 


### PR DESCRIPTION
I have updated the `replication_key` for GitHub releases to `created_at` field vs the `published_at` field. 

The `pubished_at` field can be `null` according to the [REST API endpoints for releases](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28)

This was causing the below error
```
{"TypeError: '>' not supported between instances of 'NoneType' and 'str'"}
```

`created_at` field can't be null so this should fix that.