### PR TITLE
fix: Expand CollaboratorsStream primary keys

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -747,7 +747,7 @@ class LanguagesStream(GitHubRestStream):
 class CollaboratorsStream(GitHubRestStream):
     name = "collaborators"
     path = "/repos/{org}/{repo}/collaborators"
-    primary_keys = ["id"]
+    primary_keys = ["id", "repo", "org"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys = ["repo", "org"]


### PR DESCRIPTION
The collaborators stream pulls one row per selected repo per user who is a known collaborator of that repo, so `id` (the user ID) alone isn't sufficient to describe the grain.  This PR adds `repo` and `org` to the primary keys to capture the fact that there can be a row for each user x repo pair.

My motivation is that I'm getting an error `Query error: UPDATE/MERGE must match at most one source row for each target row ...` when trying to extract this stream sequentially with `target-bigquery` and the [upsert](https://hub.meltano.com/loaders/target-bigquery/#upsert-setting) setting turned on, and that sounds related to the fact that the column set as the primary key isn't distinctive.