### PR TITLE
feat: Add `run_attempt` to `workflow_runs` schema

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1975,6 +1975,7 @@ class WorkflowRunsStream(GitHubRestStream):
         th.Property("head_branch", th.StringType),
         th.Property("head_sha", th.StringType),
         th.Property("run_number", th.IntegerType),
+        th.Property("run_attempt", th.IntegerType),
         th.Property("event", th.StringType),
         th.Property("status", th.StringType),
         th.Property("conclusion", th.StringType),


### PR DESCRIPTION
**Summary**
This pull request adds the `run_attempt` property to the workflow_runs schema. This will give the ability to filter out re-runs(`run_attempt>1`) in the workflow runs metrics.

**Changes**
Updated `repository_streams.py` to include `run_attempt` in the schema definition of the workflow_runs stream.

**Testing**
1. Confirmed that Github REST API endpoint for workflow runs response returns `run_attempt` field in the response.
2. Tested the changes locally using Meltano to ensure the `run_attempt` field is correctly included in response and populated in the target.