### PR TITLE
fix: Tokens in config are no longer ignored when there are tokens in the environment, part of refactoring in preparation for app token refreshing

### DIFF
--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -102,7 +102,7 @@ def generate_jwt_token(
     github_app_id: str,
     github_private_key: str,
     expiration_time: int = 600,
-    algorithm: str = "RS256"
+    algorithm: str = "RS256",
 ) -> str:
     actual_time = int(time.time())
 
@@ -189,12 +189,16 @@ class AppTokenManager(TokenManager):
                 '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\\n_YOUR_P_KEY_\\n-----END RSA PRIVATE KEY-----"'
             )
 
-        self.token, self.token_expires_at = generate_app_access_token(self.github_app_id, self.github_private_key, self.github_installation_id)
+        self.token, self.token_expires_at = generate_app_access_token(
+            self.github_app_id, self.github_private_key, self.github_installation_id
+        )
 
         # Check if the token isn't valid.  If not, overwrite it with None
         if not self.is_valid_token():
             if self.logger:
-                self.logger.warning("An app token was generated but could not be validated.")
+                self.logger.warning(
+                    "An app token was generated but could not be validated."
+                )
             self.token = None
             self.token_expires_at = None
 
@@ -226,7 +230,6 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
                 for key, value in env_dict.items()
                 if key.startswith("GITHUB_TOKEN")
             }
-
             if len(env_tokens) > 0:
                 self.logger.info(
                     f"Found {len(env_tokens)} 'GITHUB_TOKEN' environment variables for authentication."
@@ -235,7 +238,9 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
 
         token_managers: List[TokenManager] = []
         for token in personal_tokens:
-            token_manager = PersonalTokenManager(token, rate_limit_buffer=rate_limit_buffer, logger=self.logger)
+            token_manager = PersonalTokenManager(
+                token, rate_limit_buffer=rate_limit_buffer, logger=self.logger
+            )
             if token_manager.is_valid_token():
                 token_managers.append(token_manager)
 
@@ -245,11 +250,15 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             # "{app_id};;{-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"
             env_key = env_dict["GITHUB_APP_PRIVATE_KEY"]
             try:
-                app_token_manager = AppTokenManager(env_key, rate_limit_buffer=rate_limit_buffer, logger=self.logger)
+                app_token_manager = AppTokenManager(
+                    env_key, rate_limit_buffer=rate_limit_buffer, logger=self.logger
+                )
                 if app_token_manager.is_valid_token():
                     token_managers.append(app_token_manager)
             except ValueError as e:
-                self.logger.warn(f"An error was thrown while preparing an app token: {e}")
+                self.logger.warn(
+                    f"An error was thrown while preparing an app token: {e}"
+                )
 
         self.logger.info(f"Tap will run with {len(token_managers)} auth tokens")
         return token_managers

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 from datetime import datetime, timedelta
 from os import environ
 from random import choice, shuffle
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import jwt
 import requests
@@ -123,7 +123,7 @@ def generate_app_access_token(
     github_app_id: str,
     github_private_key: str,
     github_installation_id: Optional[str] = None,
-) -> tuple[str, datetime]:
+) -> Tuple[str, datetime]:
     produced_at = datetime.now()
     jwt_token = generate_jwt_token(github_app_id, github_private_key)
 

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -66,7 +66,7 @@ class TokenManager:
             return True
         except requests.exceptions.HTTPError:
             msg = (
-                f"A token was found to be invalid. "
+                f"A token could not be validated. "
                 f"{response.status_code} Client Error: "
                 f"{str(response.content)} (Reason: {response.reason})"
             )
@@ -243,6 +243,8 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             )
             if token_manager.is_valid_token():
                 token_managers.append(token_manager)
+            else:
+                logging.warn('A token was dismissed.')
 
         # Parse App level private key and generate a token
         if "GITHUB_APP_PRIVATE_KEY" in env_dict.keys():

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from os import environ
 from random import choice, shuffle
 from typing import Any, Dict, List, Optional, Set
@@ -15,7 +15,9 @@ from singer_sdk.streams import RESTStream
 
 
 class TokenManager:
-    """A class to store a token's attributes and state."""
+    """A class to store a token's attributes and state.
+    This parent class should not be used directly, use a subclass instead.
+    """
 
     DEFAULT_RATE_LIMIT = 5000
     # The DEFAULT_RATE_LIMIT_BUFFER buffer serves two purposes:
@@ -25,7 +27,7 @@ class TokenManager:
 
     def __init__(
         self,
-        token: str,
+        token: Optional[str],
         rate_limit_buffer: Optional[int] = None,
         logger: Optional[Any] = None,
     ):
@@ -50,6 +52,9 @@ class TokenManager:
 
     def is_valid_token(self) -> bool:
         """Try making a request with the current token. If the request succeeds return True, else False."""
+        if not self.token:
+            return False
+
         try:
             response = requests.get(
                 url="https://api.github.com/rate_limit",
@@ -61,7 +66,7 @@ class TokenManager:
             return True
         except requests.exceptions.HTTPError:
             msg = (
-                f"A token was dismissed. "
+                f"A token was found to be invalid. "
                 f"{response.status_code} Client Error: "
                 f"{str(response.content)} (Reason: {response.reason})"
             )
@@ -70,7 +75,7 @@ class TokenManager:
             return False
 
     def has_calls_remaining(self) -> bool:
-        """Check if token is valid.
+        """Check if a token has capacity to make more calls.
 
         Returns:
             True if the token is valid and has enough api calls remaining.
@@ -85,64 +90,118 @@ class TokenManager:
         return True
 
 
-def generate_jwt_token(
-    github_app_id: str,
-    github_private_key: str,
-    expiration_time: int = 600,
-    algorithm: str = "RS256",
-) -> str:
-    actual_time = int(time.time())
+class PersonalTokenManager(TokenManager):
+    """A class to store token rate limiting information."""
 
-    payload = {
-        "iat": actual_time,
-        "exp": actual_time + expiration_time,
-        "iss": github_app_id,
-    }
-    token = jwt.encode(payload, github_private_key, algorithm=algorithm)
-
-    if isinstance(token, bytes):
-        token = token.decode("utf-8")
-
-    return token
+    def __init__(self, token: str, rate_limit_buffer: Optional[int] = None, **kwargs):
+        """Init PersonalTokenRateLimit info."""
+        super().__init__(token, rate_limit_buffer=rate_limit_buffer, **kwargs)
 
 
-def generate_app_access_token(
-    github_app_id: str,
-    github_private_key: str,
-    github_installation_id: Optional[str] = None,
-) -> str:
-    jwt_token = generate_jwt_token(github_app_id, github_private_key)
 
-    headers = {"Authorization": f"Bearer {jwt_token}"}
 
-    if github_installation_id is None:
-        list_installations_resp = requests.get(
-            url="https://api.github.com/app/installations", headers=headers
+
+class AppTokenManager(TokenManager):
+    """A class to store an app token's attributes and state, and handle token refreshing"""
+
+    DEFAULT_RATE_LIMIT = 15000
+    DEFAULT_EXPIRY_BUFFER_MINS = 10
+
+    def __init__(self, env_key: str, rate_limit_buffer: Optional[int] = None, **kwargs):
+        if rate_limit_buffer is None:
+            rate_limit_buffer = self.DEFAULT_RATE_LIMIT_BUFFER
+        super().__init__(None, rate_limit_buffer=rate_limit_buffer, **kwargs)
+
+        parts = env_key.split(";;")
+        self.github_app_id = parts[0]
+        self.github_private_key = (parts[1:2] or [""])[0].replace("\\n", "\n")
+        self.github_installation_id: Optional[str] = (parts[2:3] or [""])[0]
+
+        self.token_expires_at: Optional[datetime] = None
+        self.claim_token()
+
+    def generate_jwt_token(self, expiration_time: int = 600, algorithm: str = "RS256") -> str:
+        actual_time = int(time.time())
+
+        payload = {
+            "iat": actual_time,
+            "exp": actual_time + expiration_time,
+            "iss": self.github_app_id,
+        }
+        token = jwt.encode(payload, self.github_private_key, algorithm=algorithm)
+
+        if isinstance(token, bytes):
+            token = token.decode("utf-8")
+
+        return token
+
+    def generate_app_access_token(self) -> tuple[str, datetime]:
+        produced_at = datetime.now()
+        jwt_token = self.generate_jwt_token()
+
+        headers = {"Authorization": f"Bearer {jwt_token}"}
+
+        if self.github_installation_id is None:
+            list_installations_resp = requests.get(
+                url="https://api.github.com/app/installations", headers=headers
+            )
+            list_installations_resp.raise_for_status()
+            list_installations = list_installations_resp.json()
+
+            if len(list_installations) == 0:
+                raise Exception(f"No installations found for app {self.github_app_id}.")
+
+            self.github_installation_id = choice(list_installations)["id"]
+
+        url = "https://api.github.com/app/installations/{}/access_tokens".format(
+            self.github_installation_id
         )
-        list_installations_resp.raise_for_status()
-        list_installations = list_installations_resp.json()
+        resp = requests.post(url, headers=headers)
 
-        if len(list_installations) == 0:
-            raise Exception(f"No installations found for app {github_app_id}.")
+        if resp.status_code != 201:
+            resp.raise_for_status()
 
-        github_installation_id = choice(list_installations)["id"]
+        expires_at = produced_at + timedelta(hours=1)
+        return resp.json()["token"], expires_at
 
-    url = "https://api.github.com/app/installations/{}/access_tokens".format(
-        github_installation_id
-    )
-    resp = requests.post(url, headers=headers)
+    def claim_token(self):
+        """Updates the TokenManager's token and token_expires_at attributes.
 
-    if resp.status_code != 201:
-        resp.raise_for_status()
+        The outcome will be _either_ that self.token is updated to a newly claimed valid token and
+        self.token_expires_at is updated to the anticipated expiry time (erring on the side of an early estimate)
+        _or_ self.token and self.token_expires_at are both set to None.
+        """
+        self.token = None
+        self.token_expires_at = None
 
-    return resp.json()["token"]
+        # Make sure we have the details we need
+        if not self.github_app_id or not self.github_private_key:
+            raise ValueError(
+                "GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is "
+                '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\\n_YOUR_P_KEY_\\n-----END RSA PRIVATE KEY-----"'
+            )
+
+        self.token, self.token_expires_at = self.generate_app_access_token()
+
+        # Check if the token isn't valid.  If not, overwrite it with None
+        if not self.is_valid_token():
+            if self.logger:
+                self.logger.warning("An app token was generated but could not be validated.")
+            self.token = None
+            self.token_expires_at = None
 
 
 class GitHubTokenAuthenticator(APIAuthenticatorBase):
     """Base class for offloading API auth."""
 
+    @staticmethod
+    def get_env():
+        return dict(environ)
+
     def prepare_tokens(self) -> List[TokenManager]:
-        # Save GitHub tokens
+        """Prep GitHub tokens"""
+
+        env_dict = self.get_env()
         rate_limit_buffer = self._config.get("rate_limit_buffer", None)
 
         personal_tokens: Set[str] = set()
@@ -156,52 +215,35 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             # Accept multiple tokens using environment variables GITHUB_TOKEN*
             env_tokens = {
                 value
-                for key, value in environ.items()
+                for key, value in env_dict.items()
                 if key.startswith("GITHUB_TOKEN")
             }
+
             if len(env_tokens) > 0:
                 self.logger.info(
                     f"Found {len(env_tokens)} 'GITHUB_TOKEN' environment variables for authentication."
                 )
-                personal_tokens = env_tokens
+                personal_tokens = personal_tokens.union(env_tokens)
 
         token_managers: List[TokenManager] = []
         for token in personal_tokens:
-            token_manager = TokenManager(
-                token, rate_limit_buffer=rate_limit_buffer, logger=self.logger
-            )
+            token_manager = PersonalTokenManager(token, rate_limit_buffer=rate_limit_buffer, logger=self.logger)
             if token_manager.is_valid_token():
                 token_managers.append(token_manager)
 
         # Parse App level private key and generate a token
-        if "GITHUB_APP_PRIVATE_KEY" in environ.keys():
+        if "GITHUB_APP_PRIVATE_KEY" in env_dict.keys():
             # To simplify settings, we use a single env-key formatted as follows:
             # "{app_id};;{-----BEGIN RSA PRIVATE KEY-----\n_YOUR_PRIVATE_KEY_\n-----END RSA PRIVATE KEY-----}"
-            parts = environ["GITHUB_APP_PRIVATE_KEY"].split(";;")
-            github_app_id = parts[0]
-            github_private_key = (parts[1:2] or [""])[0].replace("\\n", "\n")
-            github_installation_id = (parts[2:3] or [""])[0]
-
-            if not (github_private_key):
-                self.logger.warning(
-                    "GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is "
-                    '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\n_YOUR_P_KEY_\n-----END RSA PRIVATE KEY-----"'
-                )
-
-            else:
-                app_token = generate_app_access_token(
-                    github_app_id, github_private_key, github_installation_id or None
-                )
-                token_manager = TokenManager(
-                    app_token, rate_limit_buffer=rate_limit_buffer, logger=self.logger
-                )
-                if token_manager.is_valid_token():
-                    token_managers.append(token_manager)
+            env_key = env_dict["GITHUB_APP_PRIVATE_KEY"]
+            try:
+                app_token_manager = AppTokenManager(env_key, rate_limit_buffer=rate_limit_buffer, logger=self.logger)
+                if app_token_manager.is_valid_token():
+                    token_managers.append(app_token_manager)
+            except ValueError as e:
+                self.logger.warn(f"An error was thrown while preparing an app token: {e}")
 
         self.logger.info(f"Tap will run with {len(token_managers)} auth tokens")
-
-        # Create a dict of TokenManager
-        # TODO - separate app_token and add logic to refresh the token using generate_app_access_token.
         return token_managers
 
     def __init__(self, stream: RESTStream) -> None:

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -244,7 +244,7 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             if token_manager.is_valid_token():
                 token_managers.append(token_manager)
             else:
-                logging.warn('A token was dismissed.')
+                logging.warn("A token was dismissed.")
 
         # Parse App level private key and generate a token
         if "GITHUB_APP_PRIVATE_KEY" in env_dict.keys():

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -1,9 +1,9 @@
+import re
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-import re
 from singer_sdk.streams import RESTStream
 
 from tap_github.authenticator import (
@@ -139,12 +139,11 @@ class TestAppTokenManager:
 
     def test_initialization_with_malformed_env_key(self):
         expected_error_expression = re.escape(
-            'GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is '
+            "GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is "
             '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\\n_YOUR_P_KEY_\\n-----END RSA PRIVATE KEY-----"'
         )
         with pytest.raises(ValueError, match=expected_error_expression):
             AppTokenManager("12345key\\ncontent")
-
 
     def test_generate_token_with_invalid_credentials(self):
         with patch.object(AppTokenManager, "is_valid_token", return_value=False), patch(

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -179,7 +179,8 @@ def mock_stream():
 class TestGitHubTokenAuthenticator:
 
     def test_prepare_tokens_returns_empty_if_none_found(self, mock_stream):
-        with patch("os.environ", {"GITHUB_TLJKJFDS": "gt1"}), \
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TLJKJFDS": "gt1"}), \
                 patch.object(PersonalTokenManager, "is_valid_token", return_value=True):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -5,7 +5,13 @@ import pytest
 import requests
 
 from singer_sdk.streams import RESTStream
-from tap_github.authenticator import AppTokenManager, GitHubTokenAuthenticator, PersonalTokenManager, TokenManager
+
+from tap_github.authenticator import (
+    AppTokenManager,
+    GitHubTokenAuthenticator,
+    PersonalTokenManager,
+    TokenManager,
+)
 
 
 class TestTokenManager:
@@ -118,44 +124,44 @@ class TestTokenManager:
 class TestAppTokenManager:
 
     def test_initialization_with_3_part_env_key(self):
-        with patch.object(AppTokenManager, 'claim_token', return_value=None):
-            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
-            assert token_manager.github_app_id == '12345'
-            assert token_manager.github_private_key == 'key\ncontent'
-            assert token_manager.github_installation_id == '67890'
+        with patch.object(AppTokenManager, "claim_token", return_value=None):
+            token_manager = AppTokenManager("12345;;key\\ncontent;;67890")
+            assert token_manager.github_app_id == "12345"
+            assert token_manager.github_private_key == "key\ncontent"
+            assert token_manager.github_installation_id == "67890"
 
     def test_initialization_with_2_part_env_key(self):
-        with patch.object(AppTokenManager, 'claim_token', return_value=None):
-            token_manager = AppTokenManager('12345;;key\\ncontent')
-            assert token_manager.github_app_id == '12345'
-            assert token_manager.github_private_key == 'key\ncontent'
-            assert token_manager.github_installation_id == ''
+        with patch.object(AppTokenManager, "claim_token", return_value=None):
+            token_manager = AppTokenManager("12345;;key\\ncontent")
+            assert token_manager.github_app_id == "12345"
+            assert token_manager.github_private_key == "key\ncontent"
+            assert token_manager.github_installation_id == ""
 
     def test_initialization_with_malformed_env_key(self):
         with pytest.raises(ValueError) as exc_info:
-            AppTokenManager('12345key\\ncontent')
+            AppTokenManager("12345key\\ncontent")
 
         assert str(exc_info.value) == (
-            'GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is '
+            "GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is "
             '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\\n_YOUR_P_KEY_\\n-----END RSA PRIVATE KEY-----"'
         )
 
     def test_generate_token_with_invalid_credentials(self):
-        with patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('some_token', MagicMock())):
-            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
+        with patch.object(AppTokenManager, "is_valid_token", return_value=False), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("some_token", MagicMock())):
+            token_manager = AppTokenManager("12345;;key\\ncontent;;67890")
             assert token_manager.token is None
             assert token_manager.token_expires_at is None
 
     def test_successful_token_generation(self):
         token_time = MagicMock()
-        with patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('valid_token', token_time)):
-            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
+        with patch.object(AppTokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("valid_token", token_time)):
+            token_manager = AppTokenManager("12345;;key\\ncontent;;67890")
             token_manager.claim_token()
-            assert token_manager.token == 'valid_token'
+            assert token_manager.token == "valid_token"
             assert token_manager.token_expires_at == token_time
 
 
@@ -163,9 +169,9 @@ class TestAppTokenManager:
 def mock_stream():
     stream = MagicMock(spec=RESTStream)
     stream.logger = MagicMock()
-    stream.tap_name = 'tap_github'
+    stream.tap_name = "tap_github"
     stream.config = {
-        'rate_limit_buffer': 5
+        "rate_limit_buffer": 5
     }
     return stream
 
@@ -173,8 +179,8 @@ def mock_stream():
 class TestGitHubTokenAuthenticator:
 
     def test_prepare_tokens_returns_empty_if_none_found(self, mock_stream):
-        with patch('os.environ', {'GITHUB_TLJKJFDS': 'gt1'}), \
-                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+        with patch("os.environ", {"GITHUB_TLJKJFDS": "gt1"}), \
+                patch.object(PersonalTokenManager, "is_valid_token", return_value=True):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
@@ -182,156 +188,156 @@ class TestGitHubTokenAuthenticator:
             assert len(token_managers) == 0
 
     def test_config_auth_token_only(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'OTHER_TOKEN': 'blah', 'NOT_THE_RIGHT_TOKEN': 'meh'}), \
-                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"OTHER_TOKEN": "blah", "NOT_THE_RIGHT_TOKEN": "meh"}), \
+                patch.object(PersonalTokenManager, "is_valid_token", return_value=True):
 
             stream = mock_stream
-            stream.config.update({'auth_token': 'gt5'})
+            stream.config.update({"auth_token": "gt5"})
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 1
-            assert token_managers[0].token == 'gt5'
+            assert token_managers[0].token == "gt5"
 
     def test_config_additional_auth_tokens_only(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'OTHER_TOKEN': 'blah', 'NOT_THE_RIGHT_TOKEN': 'meh'}), \
-                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"OTHER_TOKEN": "blah", "NOT_THE_RIGHT_TOKEN": "meh"}), \
+                patch.object(PersonalTokenManager, "is_valid_token", return_value=True):
 
             stream = mock_stream
             stream.config.update({
-                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+                "additional_auth_tokens": ["gt7", "gt8", "gt9"]
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 3
-            assert sorted({tm.token for tm in token_managers}) == ['gt7', 'gt8', 'gt9']
+            assert sorted({tm.token for tm in token_managers}) == ["gt7", "gt8", "gt9"]
 
     def test_env_personal_tokens_only(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_TOKENxyz": "gt2", "OTHER_TOKEN": "blah"}), \
+                patch.object(PersonalTokenManager, "is_valid_token", return_value=True):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 2
-            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2']
+            assert sorted({tm.token for tm in token_managers}) == ["gt1", "gt2"]
 
     def test_env_app_key_only(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_APP_PRIVATE_KEY": "123;;key", "OTHER_TOKEN": "blah"}), \
+                patch.object(AppTokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 1
-            assert token_managers[0].token == 'installationtoken12345'
+            assert token_managers[0].token == "installationtoken12345"
 
     def test_all_token_types(self, mock_stream):
         # Expectations:
         # - the presence of additional_auth_tokens causes personal tokens in the environment to be ignored.
         # - the other types all coexist
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
-                                        'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_TOKENxyz": "gt2",
+                                        "GITHUB_APP_PRIVATE_KEY": "123;;key;;install_id", "OTHER_TOKEN": "blah"}), \
+                patch.object(TokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             stream = mock_stream
             stream.config.update({
-                'auth_token': 'gt5',
-                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+                "auth_token": "gt5",
+                "additional_auth_tokens": ["gt7", "gt8", "gt9"]
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 5
-            assert sorted({tm.token for tm in token_managers}) == ['gt5', 'gt7', 'gt8', 'gt9', 'installationtoken12345']
+            assert sorted({tm.token for tm in token_managers}) == ["gt5", "gt7", "gt8", "gt9", "installationtoken12345"]
 
     def test_all_token_types_except_additional_auth_tokens(self, mock_stream):
         # Expectations:
         # - in the absence of additional_auth_tokens, all the other types can coexist
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
-                                        'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_TOKENxyz": "gt2",
+                                        "GITHUB_APP_PRIVATE_KEY": "123;;key;;install_id", "OTHER_TOKEN": "blah"}), \
+                patch.object(TokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             stream = mock_stream
             stream.config.update({
-                'auth_token': 'gt5',
+                "auth_token": "gt5",
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 4
-            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2', 'gt5', 'installationtoken12345']
+            assert sorted({tm.token for tm in token_managers}) == ["gt1", "gt2", "gt5", "installationtoken12345"]
 
     def test_auth_token_and_additional_auth_tokens_deduped(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_TOKENxyz": "gt2", "OTHER_TOKEN": "blah"}), \
+                patch.object(TokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             stream = mock_stream
             stream.config.update({
-                'auth_token': 'gt1',
-                'additional_auth_tokens': ['gt1', 'gt1', 'gt8', 'gt8', 'gt9']
+                "auth_token": "gt1",
+                "additional_auth_tokens": ["gt1", "gt1", "gt8", "gt8", "gt9"]
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 3
-            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt8', 'gt9']
+            assert sorted({tm.token for tm in token_managers}) == ["gt1", "gt8", "gt9"]
 
     def test_auth_token_and_env_tokens_deduped(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENa': 'gt2', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
-                patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_TOKENa": "gt2", "GITHUB_TOKENxyz": "gt2", "OTHER_TOKEN": "blah"}), \
+                patch.object(TokenManager, "is_valid_token", return_value=True), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             stream = mock_stream
             stream.config.update({
-                'auth_token': 'gt1'
+                "auth_token": "gt1"
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()
 
             assert len(token_managers) == 2
-            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2']
+            assert sorted({tm.token for tm in token_managers}) == ["gt1", "gt2"]
 
     def test_handle_error_if_app_key_invalid(self, mock_stream):
         # Confirm expected behaviour if an error is raised while setting up the app token manager:
-        # - don't crash
+        # - don"t crash
         # - print the error as a warning
         # - continue with any other obtained tokens
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_APP_PRIVATE_KEY': '123garbagekey'}), \
-                patch('tap_github.authenticator.AppTokenManager') as mock_app_manager:
-            mock_app_manager.side_effect = ValueError('Invalid key format')
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_APP_PRIVATE_KEY": "123garbagekey"}), \
+                patch("tap_github.authenticator.AppTokenManager") as mock_app_manager:
+            mock_app_manager.side_effect = ValueError("Invalid key format")
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             auth.prepare_tokens()
 
             mock_stream.logger.warn.assert_called_with(
-                'An error was thrown while preparing an app token: Invalid key format')
+                "An error was thrown while preparing an app token: Invalid key format")
 
     def test_exclude_generated_app_token_if_invalid(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
-                patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_APP_PRIVATE_KEY": "123;;key"}), \
+                patch.object(AppTokenManager, "is_valid_token", return_value=False), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
@@ -339,17 +345,17 @@ class TestGitHubTokenAuthenticator:
             assert len(token_managers) == 0
 
     def test_prepare_tokens_returns_empty_if_all_tokens_invalid(self, mock_stream):
-        with patch.object(GitHubTokenAuthenticator, 'get_env',
-                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
-                patch.object(PersonalTokenManager, 'is_valid_token', return_value=False), \
-                patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch('tap_github.authenticator.generate_app_access_token',
-                      return_value=('installationtoken12345', MagicMock())):
+        with patch.object(GitHubTokenAuthenticator, "get_env",
+                          return_value={"GITHUB_TOKEN1": "gt1", "GITHUB_APP_PRIVATE_KEY": "123;;key"}), \
+                patch.object(PersonalTokenManager, "is_valid_token", return_value=False), \
+                patch.object(AppTokenManager, "is_valid_token", return_value=False), \
+                patch("tap_github.authenticator.generate_app_access_token",
+                      return_value=("installationtoken12345", MagicMock())):
 
             stream = mock_stream
             stream.config.update({
-                'auth_token': 'gt5',
-                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+                "auth_token": "gt5",
+                "additional_auth_tokens": ["gt7", "gt8", "gt9"]
             })
             auth = GitHubTokenAuthenticator(stream=stream)
             token_managers = auth.prepare_tokens()

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -4,7 +4,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from tap_github.authenticator import TokenManager
+from singer_sdk.streams import RESTStream
+from tap_github.authenticator import AppTokenManager, GitHubTokenAuthenticator, PersonalTokenManager, TokenManager
 
 
 class TestTokenManager:
@@ -112,3 +113,246 @@ class TestTokenManager:
         token_manager.update_rate_limit(mock_response_headers)
 
         assert not token_manager.has_calls_remaining()
+
+
+class TestAppTokenManager:
+
+    def test_initialization_with_3_part_env_key(self):
+        with patch.object(AppTokenManager, 'claim_token', return_value=None):
+            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
+            assert token_manager.github_app_id == '12345'
+            assert token_manager.github_private_key == 'key\ncontent'
+            assert token_manager.github_installation_id == '67890'
+
+    def test_initialization_with_2_part_env_key(self):
+        with patch.object(AppTokenManager, 'claim_token', return_value=None):
+            token_manager = AppTokenManager('12345;;key\\ncontent')
+            assert token_manager.github_app_id == '12345'
+            assert token_manager.github_private_key == 'key\ncontent'
+            assert token_manager.github_installation_id == ''
+
+    def test_initialization_with_malformed_env_key(self):
+        with pytest.raises(ValueError) as exc_info:
+            AppTokenManager('12345key\\ncontent')
+
+        assert str(exc_info.value) == (
+            'GITHUB_APP_PRIVATE_KEY could not be parsed. The expected format is '
+            '":app_id:;;-----BEGIN RSA PRIVATE KEY-----\\n_YOUR_P_KEY_\\n-----END RSA PRIVATE KEY-----"'
+        )
+
+    def test_generate_token_with_invalid_credentials(self):
+        with patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
+                patch('tap_github.authenticator.AppTokenManager.generate_app_access_token',
+                      return_value=('some_token', MagicMock())):
+            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
+            assert token_manager.token is None
+            assert token_manager.token_expires_at is None
+
+    def test_successful_token_generation(self):
+        token_time = MagicMock()
+        with patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
+                patch('tap_github.authenticator.AppTokenManager.generate_app_access_token',
+                      return_value=('valid_token', token_time)):
+            token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
+            token_manager.claim_token()
+            assert token_manager.token == 'valid_token'
+            assert token_manager.token_expires_at == token_time
+
+
+@pytest.fixture
+def mock_stream():
+    stream = MagicMock(spec=RESTStream)
+    stream.logger = MagicMock()
+    stream.tap_name = 'tap_github'
+    stream.config = {
+        'rate_limit_buffer': 5
+    }
+    return stream
+
+
+class TestGitHubTokenAuthenticator:
+
+    def test_prepare_tokens_returns_empty_if_none_found(self, mock_stream):
+        with patch('os.environ', {'GITHUB_TLJKJFDS': 'gt1'}), \
+                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+
+            auth = GitHubTokenAuthenticator(stream=mock_stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 0
+
+    def test_config_auth_token_only(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'OTHER_TOKEN': 'blah', 'NOT_THE_RIGHT_TOKEN': 'meh'}), \
+                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+
+            stream = mock_stream
+            stream.config.update({'auth_token': 'gt5'})
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 1
+            assert token_managers[0].token == 'gt5'
+
+    def test_config_additional_auth_tokens_only(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'OTHER_TOKEN': 'blah', 'NOT_THE_RIGHT_TOKEN': 'meh'}), \
+                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+
+            stream = mock_stream
+            stream.config.update({
+                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 3
+            assert sorted({tm.token for tm in token_managers}) == ['gt7', 'gt8', 'gt9']
+
+    def test_env_personal_tokens_only(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(PersonalTokenManager, 'is_valid_token', return_value=True):
+
+            auth = GitHubTokenAuthenticator(stream=mock_stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 2
+            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2']
+
+    def test_env_app_key_only(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            auth = GitHubTokenAuthenticator(stream=mock_stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 1
+            assert token_managers[0].token == 'installationtoken12345'
+
+    def test_all_token_types(self, mock_stream):
+        # Expectations:
+        # - the presence of additional_auth_tokens causes personal tokens in the environment to be ignored.
+        # - the other types all coexist
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
+                                        'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(TokenManager, 'is_valid_token', return_value=True), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            stream = mock_stream
+            stream.config.update({
+                'auth_token': 'gt5',
+                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 5
+            assert sorted({tm.token for tm in token_managers}) == ['gt5', 'gt7', 'gt8', 'gt9', 'installationtoken12345']
+
+    def test_all_token_types_except_additional_auth_tokens(self, mock_stream):
+        # Expectations:
+        # - in the absence of additional_auth_tokens, all the other types can coexist
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
+                                        'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(TokenManager, 'is_valid_token', return_value=True), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            stream = mock_stream
+            stream.config.update({
+                'auth_token': 'gt5',
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 4
+            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2', 'gt5', 'installationtoken12345']
+
+    def test_auth_token_and_additional_auth_tokens_deduped(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(TokenManager, 'is_valid_token', return_value=True), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            stream = mock_stream
+            stream.config.update({
+                'auth_token': 'gt1',
+                'additional_auth_tokens': ['gt1', 'gt1', 'gt8', 'gt8', 'gt9']
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 3
+            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt8', 'gt9']
+
+    def test_auth_token_and_env_tokens_deduped(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENa': 'gt2', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
+                patch.object(TokenManager, 'is_valid_token', return_value=True), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            stream = mock_stream
+            stream.config.update({
+                'auth_token': 'gt1'
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 2
+            assert sorted({tm.token for tm in token_managers}) == ['gt1', 'gt2']
+
+    def test_handle_error_if_app_key_invalid(self, mock_stream):
+        # Confirm expected behaviour if an error is raised while setting up the app token manager:
+        # - don't crash
+        # - print the error as a warning
+        # - continue with any other obtained tokens
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_APP_PRIVATE_KEY': '123garbagekey'}), \
+                patch('tap_github.authenticator.AppTokenManager') as mock_app_manager:
+            mock_app_manager.side_effect = ValueError('Invalid key format')
+
+            auth = GitHubTokenAuthenticator(stream=mock_stream)
+            auth.prepare_tokens()
+
+            mock_stream.logger.warn.assert_called_with(
+                'An error was thrown while preparing an app token: Invalid key format')
+
+    def test_exclude_generated_app_token_if_invalid(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
+                patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            auth = GitHubTokenAuthenticator(stream=mock_stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 0
+
+    def test_prepare_tokens_returns_empty_if_all_tokens_invalid(self, mock_stream):
+        with patch.object(GitHubTokenAuthenticator, 'get_env',
+                          return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
+                patch.object(PersonalTokenManager, 'is_valid_token', return_value=False), \
+                patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
+                patch.object(AppTokenManager, 'generate_app_access_token',
+                             return_value=('installationtoken12345', MagicMock())):
+
+            stream = mock_stream
+            stream.config.update({
+                'auth_token': 'gt5',
+                'additional_auth_tokens': ['gt7', 'gt8', 'gt9']
+            })
+            auth = GitHubTokenAuthenticator(stream=stream)
+            token_managers = auth.prepare_tokens()
+
+            assert len(token_managers) == 0
+

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -142,7 +142,7 @@ class TestAppTokenManager:
 
     def test_generate_token_with_invalid_credentials(self):
         with patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch('tap_github.authenticator.AppTokenManager.generate_app_access_token',
+                patch('tap_github.authenticator.generate_app_access_token',
                       return_value=('some_token', MagicMock())):
             token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
             assert token_manager.token is None
@@ -151,7 +151,7 @@ class TestAppTokenManager:
     def test_successful_token_generation(self):
         token_time = MagicMock()
         with patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
-                patch('tap_github.authenticator.AppTokenManager.generate_app_access_token',
+                patch('tap_github.authenticator.generate_app_access_token',
                       return_value=('valid_token', token_time)):
             token_manager = AppTokenManager('12345;;key\\ncontent;;67890')
             token_manager.claim_token()
@@ -224,8 +224,8 @@ class TestGitHubTokenAuthenticator:
         with patch.object(GitHubTokenAuthenticator, 'get_env',
                           return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key', 'OTHER_TOKEN': 'blah'}), \
                 patch.object(AppTokenManager, 'is_valid_token', return_value=True), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
@@ -241,8 +241,8 @@ class TestGitHubTokenAuthenticator:
                           return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
                                         'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
                 patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             stream = mock_stream
             stream.config.update({
@@ -262,8 +262,8 @@ class TestGitHubTokenAuthenticator:
                           return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2',
                                         'GITHUB_APP_PRIVATE_KEY': '123;;key;;install_id', 'OTHER_TOKEN': 'blah'}), \
                 patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             stream = mock_stream
             stream.config.update({
@@ -279,8 +279,8 @@ class TestGitHubTokenAuthenticator:
         with patch.object(GitHubTokenAuthenticator, 'get_env',
                           return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
                 patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             stream = mock_stream
             stream.config.update({
@@ -297,8 +297,8 @@ class TestGitHubTokenAuthenticator:
         with patch.object(GitHubTokenAuthenticator, 'get_env',
                           return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_TOKENa': 'gt2', 'GITHUB_TOKENxyz': 'gt2', 'OTHER_TOKEN': 'blah'}), \
                 patch.object(TokenManager, 'is_valid_token', return_value=True), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             stream = mock_stream
             stream.config.update({
@@ -330,8 +330,8 @@ class TestGitHubTokenAuthenticator:
         with patch.object(GitHubTokenAuthenticator, 'get_env',
                           return_value={'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
                 patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             auth = GitHubTokenAuthenticator(stream=mock_stream)
             token_managers = auth.prepare_tokens()
@@ -343,8 +343,8 @@ class TestGitHubTokenAuthenticator:
                           return_value={'GITHUB_TOKEN1': 'gt1', 'GITHUB_APP_PRIVATE_KEY': '123;;key'}), \
                 patch.object(PersonalTokenManager, 'is_valid_token', return_value=False), \
                 patch.object(AppTokenManager, 'is_valid_token', return_value=False), \
-                patch.object(AppTokenManager, 'generate_app_access_token',
-                             return_value=('installationtoken12345', MagicMock())):
+                patch('tap_github.authenticator.generate_app_access_token',
+                      return_value=('installationtoken12345', MagicMock())):
 
             stream = mock_stream
             stream.config.update({


### PR DESCRIPTION
This PR continues the work started in https://github.com/MeltanoLabs/tap-github/pull/281, completing the major refactor. This is accomplished by creating PersonalTokenManager and AppTokenManager classes, moving logic to them, and adding tests.

After this PR, I'll be able to easily implement refreshing for app tokens and other app token related features.

In additional to the added unit tests, I have tested running an extractor on top of the proposed code, in a couple scenarios:

with auth_token? | with additional_auth_tokens? | with personal tokens in env? | with app token? | # tokens that should be used | # tokens used in test run
--|--|--|--|--|--
no | no | no | yes | 1 | 1 ✅ 
yes | yes (1) | no | yes | 3 | 3 ✅ 
no | yes (2) | no | yes | 3 | 3 ✅ 

I am not easily able to test the case of personal tokens being detected from the environment, just because changing the name of environment variables is not simple in my set up.