### PR TITLE
fix: fix problem when app token used without installation ID provided

### DIFF
--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -167,7 +167,9 @@ class AppTokenManager(TokenManager):
         parts = env_key.split(";;")
         self.github_app_id = parts[0]
         self.github_private_key = (parts[1:2] or [""])[0].replace("\\n", "\n")
-        self.github_installation_id: Optional[str] = (parts[2:3] or [""])[0]
+        self.github_installation_id: Optional[str] = (
+            parts[2] if len(parts) >= 3 else None
+        )
 
         self.token_expires_at: Optional[datetime] = None
         self.claim_token()

--- a/tap_github/tests/test_authenticator.py
+++ b/tap_github/tests/test_authenticator.py
@@ -135,7 +135,7 @@ class TestAppTokenManager:
             token_manager = AppTokenManager("12345;;key\\ncontent")
             assert token_manager.github_app_id == "12345"
             assert token_manager.github_private_key == "key\ncontent"
-            assert token_manager.github_installation_id == ""
+            assert token_manager.github_installation_id is None
 
     def test_initialization_with_malformed_env_key(self):
         expected_error_expression = re.escape(


### PR DESCRIPTION
Addresses the problem described by @camerondavison [here](https://github.com/MeltanoLabs/tap-github/pull/284#discussion_r1717520222), and introduced in https://github.com/MeltanoLabs/tap-github/pull/284.

If not provided, installation ID should be set to None, since that is the way `generate_app_access_token` expects a missing installation ID to be represented.