### PR TITLE
feat: include records for failed PR diff fetches in `PullRequestDiffsStream`

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1449,6 +1449,7 @@ class PullRequestDiffsStream(GitHubRestStream):
     parent_stream_type = PullRequestsStream
     ignore_parent_replication_key = False
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
+    # Known Github API errors
     tolerated_http_errors: ClassVar[list[int]] = [404, 406, 422, 502]
 
     @property
@@ -1460,6 +1461,16 @@ class PullRequestDiffsStream(GitHubRestStream):
     def parse_response(self, response: requests.Response) -> Iterable[dict]:
         """Parse the response to yield the diff text instead of an object and prevent buffer overflow."""  # noqa: E501
         if response.status_code != 200:
+            contents = response.json()
+            self.logger.info(
+                "Skipping PR due to %d error: %s",
+                response.status_code,
+                contents["message"],
+            )
+            yield {
+                "success": False,
+                "error_message": contents["message"],
+            }
             return
 
         if content_length_str := response.headers.get("Content-Length"):
@@ -1471,21 +1482,13 @@ class PullRequestDiffsStream(GitHubRestStream):
                     "limit of 40 MiB.",
                     content_length / 1024 / 1024,
                 )
+                yield {
+                    "success": False,
+                    "error_message": "Diff exceeded the maximum size limit of 40 MiB.",
+                }
                 return
 
-        yield {"diff": response.text}
-
-    def validate_response(self, response: requests.Response) -> None:
-        """Allow some specific errors."""
-        if response.status_code in self.tolerated_http_errors:
-            contents = response.json()
-            self.logger.info(
-                "Skipping PR due to %d error: %s",
-                response.status_code,
-                contents["message"],
-            )
-            return
-        super().validate_response(response)
+        yield {"diff": response.text, "success": True}
 
     def post_process(self, row: dict, context: dict[str, str] | None = None) -> dict:
         row = super().post_process(row, context)
@@ -1507,6 +1510,8 @@ class PullRequestDiffsStream(GitHubRestStream):
         th.Property("pull_id", th.IntegerType),
         # Rest
         th.Property("diff", th.StringType),
+        th.Property("success", th.BooleanType),
+        th.Property("error_message", th.StringType),
     ).to_dict()
 
 

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1449,7 +1449,7 @@ class PullRequestDiffsStream(GitHubRestStream):
     parent_stream_type = PullRequestsStream
     ignore_parent_replication_key = False
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
-    tolerated_http_errors: ClassVar[list[int]] = [406, 422, 502]
+    tolerated_http_errors: ClassVar[list[int]] = [404, 406, 422, 502]
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1471,7 +1471,7 @@ class PullRequestDiffsStream(GitHubRestStream):
                     "limit of 40 MiB.",
                     content_length / 1024 / 1024,
                 )
-            return
+                return
 
         yield {"diff": response.text}
 


### PR DESCRIPTION
This PR also contains some forward fixes following https://github.com/MeltanoLabs/tap-github/pull/345, namely
- a mis-indented `return` statement was causing all PR diff records to be 'skipped'
- added `404` to list of known Github API errors

For completeness purposes, 2 new PR diff properties have been added: `success` and `error_message`.
- If a PR diff is successfully fetched, `success`=`True` and `error_message` is null.
- If a PR diff is 'skipped' for any reason (e.g., GIthub API error, diff size is too large) a record will still be made for it with `success`=`False` and the respective `error_message` (so users can at least know which PRs have diffs that weren't retrieved).

 I've tested my changes on my end and it all seems to be working successfully (records being produced with the new attributes set correctly), though please advise if I missed anything. Thank you!
