### PR TITLE
feat: Updated primary key to include name in `branches` and `tags` streams

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -2560,7 +2560,7 @@ class BranchesStream(GitHubRestStream):
 
     name = "branches"
     path = "/repos/{org}/{repo}/branches"
-    primary_keys: ClassVar[list[str]] = ["repo", "org"]
+    primary_keys: ClassVar[list[str]] = ["repo", "org", "name"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
@@ -2602,7 +2602,7 @@ class TagsStream(GitHubRestStream):
 
     name = "tags"
     path = "/repos/{org}/{repo}/tags"
-    primary_keys: ClassVar[list[str]] = ["repo", "org"]
+    primary_keys: ClassVar[list[str]] = ["repo", "org", "name"]
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]


### PR DESCRIPTION
Fixing a bug in the new BranchesStream and TagsStream that was brought in this last [PR](https://github.com/MeltanoLabs/tap-github/pull/357). By not having the `name` in the primary keys it returns one data entry per org/repo. This should allow the stream to pick up all tags and branches in a given repo now. (tested this downstream and it works as expected)