### PR TITLE
feat: Add support for organization members

### DIFF
--- a/tap_github/organization_streams.py
+++ b/tap_github/organization_streams.py
@@ -67,6 +67,34 @@ class OrganizationStream(GitHubRestStream):
     ).to_dict()
 
 
+class OrgMembersStream(GitHubRestStream):
+    """
+    API Reference: https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#list-organization-members
+    """
+
+    name = "org_members"
+    primary_keys: ClassVar[list[str]] = ["id"]
+    path = "/orgs/{org}/members"
+    ignore_parent_replication_key = True
+    parent_stream_type = OrganizationStream
+    state_partitioning_keys: ClassVar[list[str]] = ["org"]
+
+    schema = th.PropertiesList(
+        # Parent keys
+        th.Property("org", th.StringType),
+        # Rest
+        th.Property("login", th.StringType),
+        th.Property("id", th.IntegerType),
+        th.Property("node_id", th.StringType),
+        th.Property("avatar_url", th.StringType),
+        th.Property("gravatar_id", th.StringType),
+        th.Property("url", th.StringType),
+        th.Property("html_url", th.StringType),
+        th.Property("type", th.StringType),
+        th.Property("site_admin", th.BooleanType),
+    ).to_dict()
+
+
 class TeamsStream(GitHubRestStream):
     """
     API Reference: https://docs.github.com/en/rest/reference/teams#list-teams

--- a/tap_github/organization_streams.py
+++ b/tap_github/organization_streams.py
@@ -67,18 +67,17 @@ class OrganizationStream(GitHubRestStream):
     ).to_dict()
 
 
-class OrgMembersStream(GitHubRestStream):
+class OrganizationMembersStream(GitHubRestStream):
     """
     API Reference: https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#list-organization-members
     """
 
-    name = "org_members"
+    name = "organization_members"
     primary_keys: ClassVar[list[str]] = ["id"]
     path = "/orgs/{org}/members"
     ignore_parent_replication_key = True
     parent_stream_type = OrganizationStream
     state_partitioning_keys: ClassVar[list[str]] = ["org"]
-
     schema = th.PropertiesList(
         # Parent keys
         th.Property("org", th.StringType),

--- a/tap_github/streams.py
+++ b/tap_github/streams.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 
 from tap_github.organization_streams import (
+    OrganizationMembersStream,
     OrganizationStream,
     TeamMembersStream,
     TeamRolesStream,
@@ -130,7 +131,13 @@ class Streams(Enum):
     )
     ORGANIZATIONS = (
         {"organizations"},
-        [OrganizationStream, TeamMembersStream, TeamRolesStream, TeamsStream],
+        [
+            OrganizationStream,
+            OrganizationMembersStream,
+            TeamMembersStream,
+            TeamRolesStream,
+            TeamsStream,
+        ],
     )
 
     @classmethod


### PR DESCRIPTION
Adds into the Organzation Stream a way to also get organization members. There is currently a team members, but not all members for the org are captured by that. 