### PR TITLE
fix: check for null row["issue"] in issue events stream

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1028,9 +1028,9 @@ class IssueEventsStream(GitHubRestStream):
 
     def post_process(self, row: dict, context: dict | None = None) -> dict:
         row = super().post_process(row, context)
-        if "issue" in row and row["issue"] is not None:
-            row["issue_number"] = int(row["issue"].pop("number"))
-            row["issue_url"] = row["issue"].pop("url")
+        if issue := row.get("issue"):
+            row["issue_number"] = int(issue.pop("number"))
+            row["issue_url"] = issue.pop("url")
         else:
             self.logger.debug(
                 f"No issue assosciated with event {row['id']} - {row['event']}."

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1028,7 +1028,7 @@ class IssueEventsStream(GitHubRestStream):
 
     def post_process(self, row: dict, context: dict | None = None) -> dict:
         row = super().post_process(row, context)
-        if "issue" in row:
+        if "issue" in row and row["issue"] is not None:
             row["issue_number"] = int(row["issue"].pop("number"))
             row["issue_url"] = row["issue"].pop("url")
         else:


### PR DESCRIPTION
We ran into an `AttributeError: 'NoneType' object has no attribute 'pop'` error while testing the IssueEventsStream, it's originating from [this line](https://github.com/MeltanoLabs/tap-github/blob/9033fe4d2b28386c6e8c6fb02262d80b862cd05d/tap_github/repository_streams.py#L1032).

It appears to be possible for row to have an `issue` key but for its value in the dict to be None.  This PR adds a check for it.

We've tested the fix on our end successfully.