### PR TITLE
fix: Move tolerated errors to parent `GitHubDiffStream` class

### DIFF
--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -308,6 +308,8 @@ class GitHubRestStream(RESTStream):
 
 class GitHubDiffStream(GitHubRestStream):
     """Base class for GitHub diff streams."""
+    # Known Github API errors for diff requests
+    tolerated_http_errors: ClassVar[list[int]] = [404, 406, 422, 502]
 
     @property
     def http_headers(self) -> dict:

--- a/tap_github/client.py
+++ b/tap_github/client.py
@@ -308,6 +308,7 @@ class GitHubRestStream(RESTStream):
 
 class GitHubDiffStream(GitHubRestStream):
     """Base class for GitHub diff streams."""
+
     # Known Github API errors for diff requests
     tolerated_http_errors: ClassVar[list[int]] = [404, 406, 422, 502]
 

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1498,8 +1498,6 @@ class PullRequestDiffsStream(GitHubDiffStream):
     parent_stream_type = PullRequestsStream
     ignore_parent_replication_key = False
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
-    # Known Github API errors
-    tolerated_http_errors: ClassVar[list[int]] = [404, 406, 422, 502]
 
     def post_process(self, row: dict, context: dict[str, str] | None = None) -> dict:
         row = super().post_process(row, context)


### PR DESCRIPTION
Small followup to https://github.com/MeltanoLabs/tap-github/pull/372. 
Realized that the `tolerated_http_errors` should be the same for all `GithubDiffsStream` class members, not only `PullRequestDiffs`. I have verified that changes work as expected 👍🏻 

Thank you in advance!