### PR TITLE
fix: Implement cursor-based pagination and use it for IssuesStream

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -842,6 +842,7 @@ class IssuesStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
+    use_cursor_pagination = True
 
     def get_url_params(
         self,


### PR DESCRIPTION
We've begun getting this error for one of our orgs:
> Pagination with the page parameter is not supported for large datasets, please use cursor based pagination (after/before)

I suspect Github has added a new restriction here as we haven't see this issue in the past even with large scale extractions, and it's happening now with a relatively small one.

This PR adds a class variable `use_cursor_pagination` in `GitHubRestStream` that can be toggled to have a given stream subclass use cursor-based pagination instead.  I'm leaving it False by default and only setting it to True in `IssuesStream` because I don't know if other endpoints support it.  If it turns out to be needed in other streams in the future, it should be easy to set.

I've successfully tested this change in my environment.