### PR TITLE
feat: Add replication key for review comments

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1613,6 +1613,7 @@ class ReviewCommentsStream(GitHubRestStream):
     name = "review_comments"
     path = "/repos/{org}/{repo}/pulls/comments"
     primary_keys: ClassVar[list[str]] = ["id"]
+    replication_key = "updated_at"
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]


### PR DESCRIPTION
Without this, even if a start date is specified in config it will still extract from the beginning of time.

(not sure if this is considered a feature or a fix, feel free to rename accordingly)