### PR TITLE
feat: Make ProjectItemsStream skip project if query can't be validated

### DIFF
--- a/tap_github/organization_streams.py
+++ b/tap_github/organization_streams.py
@@ -653,6 +653,11 @@ class ProjectItemsStream(GitHubGraphqlStream):
                     f"Context: {context}. Error: {e}"
                 )
                 return
+            elif "Timeout on validation of query" in error_message:
+                self.logger.warning(
+                    f"Skipping project due to query validation timeout error. "
+                    f"Context: {context}. Error: {e}"
+                )
 
             raise
 


### PR DESCRIPTION
We've seen this error thrown regularly:
```
singer_sdk.exceptions.FatalAPIError: (\"Graphql error: [{'message': 'Timeout on validation of query'}]\", <Response [200]>)
```

We suspect this happens because of project boards in the extraction scope that have especially complex structures which lead to extra complex GraphQL queries which are slower to validate. This PR makes it so these projects will be skipped rather than causing the tap to fail.