### PR TITLE
fix: Keep org-specific token rotation isolated

### DIFF
--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -525,31 +525,35 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
     def get_next_auth_token(self) -> None:
         current_token = self.active_token.token if self.active_token else ""
 
-        # Build a list of candidate tokens for the current organization
+        # Build a list of candidate tokens for the current organization.
+        # If the current org has a configured token pool, stay within that pool.
+        # Installation tokens are org-scoped, so falling through to another org's
+        # token can turn legitimate private-repo calls into misleading 404s.
         candidates = []
-
-        # Priority 1: Other tokens for the current organization
-        if (
+        has_current_org_tokens = (
             self.current_organization
             and self.current_organization in self.token_managers
-        ):
+            and self.token_managers[self.current_organization]
+        )
+
+        if has_current_org_tokens:
             org_tokens = list(self.token_managers[self.current_organization])
             shuffle(org_tokens)
             candidates.extend(org_tokens)
+        else:
+            # Priority 2: Org-agnostic tokens (stored under None key)
+            if None in self.token_managers:
+                agnostic_tokens = list(self.token_managers[None])
+                shuffle(agnostic_tokens)
+                candidates.extend(agnostic_tokens)
 
-        # Priority 2: Org-agnostic tokens (stored under None key)
-        if None in self.token_managers:
-            agnostic_tokens = list(self.token_managers[None])
-            shuffle(agnostic_tokens)
-            candidates.extend(agnostic_tokens)
-
-        # Priority 3: Tokens from other organizations (for public data access)
-        # GitHub tokens can access public data from any org
-        for org, tokens in self.token_managers.items():
-            if org != self.current_organization and org is not None:
-                other_org_tokens = list(tokens)
-                shuffle(other_org_tokens)
-                candidates.extend(other_org_tokens)
+            # Priority 3: Tokens from other organizations (for public data access)
+            # GitHub tokens can access public data from any org
+            for org, tokens in self.token_managers.items():
+                if org != self.current_organization and org is not None:
+                    other_org_tokens = list(tokens)
+                    shuffle(other_org_tokens)
+                    candidates.extend(other_org_tokens)
 
         # Try to find a token with remaining capacity
         for token_manager in candidates:

--- a/tap_github/authenticator.py
+++ b/tap_github/authenticator.py
@@ -536,6 +536,7 @@ class GitHubTokenAuthenticator(APIAuthenticatorBase):
             and self.token_managers[self.current_organization]
         )
 
+        # Priority 1: Tokens scoped to the current org
         if has_current_org_tokens:
             org_tokens = list(self.token_managers[self.current_organization])
             shuffle(org_tokens)

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -742,8 +742,10 @@ class TestGitHubTokenAuthenticator:
                     assert auth.active_token == org_tokens[1]
                     assert auth.current_organization == "acme-corp"
 
-    def test_get_next_auth_token_falls_back_to_org_agnostic(self, mock_stream):
-        """Test that token rotation falls back to org-agnostic tokens."""
+    def test_get_next_auth_token_keeps_org_specific_tokens_isolated(
+        self, mock_stream
+    ):
+        """Test org-specific token rotation does not fall back to agnostic tokens."""
         with (
             patch.object(
                 GitHubTokenAuthenticator,
@@ -768,26 +770,26 @@ class TestGitHubTokenAuthenticator:
             ):
                 auth = GitHubTokenAuthenticator.from_stream(stream=stream)
 
-                # Get tokens
                 org_token = auth.token_managers["acme-corp"][0]
                 agnostic_token = auth.token_managers[None][0]
 
-                # Set current org with exhausted token
                 auth.current_organization = "acme-corp"
                 auth.active_token = org_token
 
-                # Mock org-specific token as exhausted, agnostic as available
                 with (
                     patch.object(org_token, "has_calls_remaining", return_value=False),
                     patch.object(
                         agnostic_token, "has_calls_remaining", return_value=True
                     ),
+                    pytest.raises(
+                        RuntimeError,
+                        match="All GitHub tokens have hit their rate limit",
+                    ),
                 ):
-                    # Should fall back to agnostic token
                     auth.get_next_auth_token()
 
-                    assert auth.active_token == agnostic_token
-                    assert auth.current_organization == "acme-corp"
+                assert auth.active_token == org_token
+                assert auth.current_organization == "acme-corp"
 
     def test_get_next_auth_token_raises_when_all_exhausted(self, mock_stream):
         """Test that get_next_auth_token raises when all tokens are exhausted."""
@@ -1232,16 +1234,21 @@ class TestGitHubTokenAuthenticator:
                     assert auth.active_token == acme_token
                     assert auth.current_organization == "acme-corp"
 
-                # Test 2: Should fall back to org-agnostic when org-specific exhausted
+                # Test 2: Should not fall back when org-specific tokens are exhausted
                 with (
                     patch.object(acme_token, "has_calls_remaining", return_value=False),
                     patch.object(
                         fallback_token, "has_calls_remaining", return_value=True
                     ),
+                    pytest.raises(
+                        RuntimeError,
+                        match="All GitHub tokens have hit their rate limit",
+                    ),
                 ):
                     auth.get_next_auth_token()
-                    assert auth.active_token == fallback_token
-                    assert auth.current_organization == "acme-corp"
+
+                assert auth.active_token == acme_token
+                assert auth.current_organization == "acme-corp"
 
                 # Test 3: Org without specific tokens should use fallback
                 with (

--- a/tests/test_authenticator.py
+++ b/tests/test_authenticator.py
@@ -742,9 +742,7 @@ class TestGitHubTokenAuthenticator:
                     assert auth.active_token == org_tokens[1]
                     assert auth.current_organization == "acme-corp"
 
-    def test_get_next_auth_token_keeps_org_specific_tokens_isolated(
-        self, mock_stream
-    ):
+    def test_get_next_auth_token_keeps_org_specific_tokens_isolated(self, mock_stream):
         """Test org-specific token rotation does not fall back to agnostic tokens."""
         with (
             patch.object(


### PR DESCRIPTION
## Summary

Keep token rotation scoped to the current organization when that organization has its own configured token pool.

GitHub App installation tokens are org-scoped. If a stream is reading private repositories for one org and `get_next_auth_token()` falls through to another org's installation token, GitHub can return misleading `404 Not Found` responses for repositories that do exist and are accessible with the correct org token.

## What changed

- `get_next_auth_token()` now prefers the current organization's token managers when `current_organization` has a configured token pool.
- Fallback to org-agnostic or other-org tokens is still allowed when the current organization has no configured token pool.
- Added regression tests for both paths:
  - org-specific token rotation stays inside the current org's pool.
  - missing org-specific pools still use the existing fallback behavior.

## Validation

```text
uv run pytest tests/test_authenticator.py
# 44 passed
```
