### PR TITLE
ci: Use `astral-sh/setup-uv` action directly and skip `actions/setup-python`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       ORG_LEVEL_TOKEN: ${{secrets.ORG_LEVEL_TOKEN}}
-      UV_PYTHON: ${{ matrix.python-version }}
+      TOX_GH_MAJOR_MINOR: ${{ matrix.python-version }}
     strategy:
       matrix:
         python-version:
@@ -67,16 +67,10 @@ jobs:
         # file in the cache. See issue #119
         key: api-cache-v4-${{ steps.get-date.outputs.date }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      id: setup-python
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-
     - name: Install uv
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
+      with:
+        python-version: ${{ matrix.python-version }}
 
     - name: Install Tox
       run: |


### PR DESCRIPTION
SSIA