### PR TITLE
fix: support repositories with pull requests disabled

### DIFF
--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -335,6 +335,40 @@ class RepositoryStream(GitHubRestStream):
     ).to_dict()
 
 
+class RepositoryFeatureGatedStream(GitHubRestStream):
+    """REST stream that skips API calls for explicitly disabled repo features."""
+
+    required_repository_features: ClassVar[tuple[str, ...]] = ()
+
+    def _disabled_repository_feature(self, context: Context | None) -> str | None:
+        """Return the first explicitly disabled repository feature, if any."""
+        if context is None:
+            return None
+
+        for feature in self.required_repository_features:
+            if context.get(feature) is False:
+                return feature
+
+        return None
+
+    def get_records(self, context: Context | None = None) -> Iterable[dict[str, Any]]:
+        """Return records unless repository metadata explicitly disables a feature."""
+        if disabled_feature := self._disabled_repository_feature(context):
+            org = context.get("org", "unknown") if context is not None else "unknown"
+            repo = context.get("repo", "unknown") if context is not None else "unknown"
+            self.logger.info(
+                "Skipping '%s' for repository %s/%s because repository feature "
+                "'%s' is disabled",
+                self.name,
+                org,
+                repo,
+                disabled_feature,
+            )
+            return []
+
+        return super().get_records(context)
+
+
 class ReadmeStream(GitHubRestStream):
     """
     A stream dedicated to fetching the object version of a README.md.
@@ -1291,7 +1325,7 @@ class LabelsStream(GitHubRestStream):
     ).to_dict()
 
 
-class PullRequestsStream(GitHubRestStream):
+class PullRequestsStream(RepositoryFeatureGatedStream):
     """Defines 'PullRequests' stream."""
 
     name = "pull_requests"
@@ -1301,24 +1335,9 @@ class PullRequestsStream(GitHubRestStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
+    required_repository_features: ClassVar[tuple[str, ...]] = ("has_pull_requests",)
     # GitHub is missing the "since" parameter on this endpoint.
     use_fake_since_parameter = True
-
-    def get_records(self, context: Context | None = None) -> Iterable[dict[str, Any]]:
-        """Return pull request records, skipping repos with PRs disabled."""
-        assert context is not None, f"Context cannot be empty for '{self.name}' stream"
-
-        if context.get("has_pull_requests") is False:
-            org = context.get("org", "unknown")
-            repo = context.get("repo", "unknown")
-            self.logger.info(
-                "Repository %s/%s: Pull requests not enabled, skipping API call",
-                org,
-                repo,
-            )
-            return []
-
-        return super().get_records(context)
 
     def get_url_params(
         self,

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -1320,9 +1320,6 @@ class PullRequestsStream(GitHubRestStream):
             )
             return []
 
-        self.logger.debug(
-            f"Repository {org}/{repo}: Pull requests enabled, making API call",
-        )
         return super().get_records(context)
 
     def get_url_params(

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -243,6 +243,7 @@ class RepositoryStream(GitHubRestStream):
             "has_discussions": record.get(
                 "has_discussions", False
             ),  # GitHub repos not updated after the feature was released in 2021 will not have this field. # noqa: E501
+            "has_pull_requests": record.get("has_pull_requests", True),
         }
 
     def get_records(self, context: Context | None) -> Iterable[dict[str, Any]]:
@@ -324,6 +325,7 @@ class RepositoryStream(GitHubRestStream):
         th.Property("network_count", th.IntegerType),
         th.Property("subscribers_count", th.IntegerType),
         th.Property("open_issues_count", th.IntegerType),
+        th.Property("has_pull_requests", th.BooleanType),
         th.Property("allow_squash_merge", th.BooleanType),
         th.Property("allow_merge_commit", th.BooleanType),
         th.Property("allow_rebase_merge", th.BooleanType),
@@ -1301,6 +1303,22 @@ class PullRequestsStream(GitHubRestStream):
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
     # GitHub is missing the "since" parameter on this endpoint.
     use_fake_since_parameter = True
+
+    def get_records(self, context: Context | None = None) -> Iterable[dict[str, Any]]:
+        """Return pull request records, skipping repos with PRs disabled."""
+        assert context is not None, f"Context cannot be empty for '{self.name}' stream"
+
+        if context.get("has_pull_requests") is False:
+            org = context.get("org", "unknown")
+            repo = context.get("repo", "unknown")
+            self.logger.info(
+                "Repository %s/%s: Pull requests not enabled, skipping API call",
+                org,
+                repo,
+            )
+            return []
+
+        return super().get_records(context)
 
     def get_url_params(
         self,

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -335,39 +335,6 @@ class RepositoryStream(GitHubRestStream):
     ).to_dict()
 
 
-class RepositoryFeatureGatedStream(GitHubRestStream):
-    """REST stream that skips API calls for explicitly disabled repo features."""
-
-    required_repository_features: ClassVar[tuple[str, ...]] = ()
-
-    def _disabled_repository_feature(self, context: Context | None) -> str | None:
-        """Return the first explicitly disabled repository feature, if any."""
-        if context is None:
-            return None
-
-        for feature in self.required_repository_features:
-            if context.get(feature) is False:
-                return feature
-
-        return None
-
-    def get_records(self, context: Context | None = None) -> Iterable[dict[str, Any]]:
-        """Return records unless repository metadata explicitly disables a feature."""
-        if disabled_feature := self._disabled_repository_feature(context):
-            org = context.get("org", "unknown") if context is not None else "unknown"
-            repo = context.get("repo", "unknown") if context is not None else "unknown"
-            self.logger.info(
-                "Skipping '%s' for repository %s/%s because repository feature "
-                "'%s' is disabled",
-                self.name,
-                org,
-                repo,
-                disabled_feature,
-            )
-            return []
-
-        return super().get_records(context)
-
 
 class ReadmeStream(GitHubRestStream):
     """
@@ -1325,7 +1292,7 @@ class LabelsStream(GitHubRestStream):
     ).to_dict()
 
 
-class PullRequestsStream(RepositoryFeatureGatedStream):
+class PullRequestsStream(GitHubRestStream):
     """Defines 'PullRequests' stream."""
 
     name = "pull_requests"
@@ -1335,9 +1302,29 @@ class PullRequestsStream(RepositoryFeatureGatedStream):
     parent_stream_type = RepositoryStream
     ignore_parent_replication_key = True
     state_partitioning_keys: ClassVar[list[str]] = ["repo", "org"]
-    required_repository_features: ClassVar[tuple[str, ...]] = ("has_pull_requests",)
     # GitHub is missing the "since" parameter on this endpoint.
     use_fake_since_parameter = True
+
+    def get_records(self, context: Context | None = None) -> Iterable[dict[str, Any]]:
+        """
+        Return a generator of row-type dictionary objects.
+        If pull requests are not enabled, skip the API call.
+        """
+        assert context is not None, f"Context cannot be empty for '{self.name}' stream"
+
+        repo = context.get("repo", "unknown")
+        org = context.get("org", "unknown")
+        if context.get("has_pull_requests", True) is False:
+            self.logger.debug(
+                f"Repository {org}/{repo}: Pull requests not enabled, "
+                "skipping API call",
+            )
+            return []
+
+        self.logger.debug(
+            f"Repository {org}/{repo}: Pull requests enabled, making API call",
+        )
+        return super().get_records(context)
 
     def get_url_params(
         self,

--- a/tap_github/repository_streams.py
+++ b/tap_github/repository_streams.py
@@ -335,7 +335,6 @@ class RepositoryStream(GitHubRestStream):
     ).to_dict()
 
 
-
 class ReadmeStream(GitHubRestStream):
     """
     A stream dedicated to fetching the object version of a README.md.

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -10,6 +10,7 @@ from dateutil.parser import isoparse
 from singer_sdk.helpers import _catalog as cat_helpers
 from singer_sdk.singerlib import Catalog
 
+from tap_github.repository_streams import GitHubRestStream
 from tap_github.scraping import parse_counter
 from tap_github.tap import TapGitHub
 
@@ -124,6 +125,90 @@ def test_get_a_repository_in_repo_list_mode(
     # check that the tap corrects invalid case in config input
     assert '"repo": "Tap-GitLab"' not in captured_out
     assert '"org": "meltanolabs"' not in captured_out
+
+
+def test_repository_child_context_includes_pull_request_capability(repo_list_config):  # noqa: F811
+    """Verify repository context includes the pull request capability flag."""
+    tap = TapGitHub(config=repo_list_config)
+    repository_stream = tap.streams["repositories"]
+
+    context = repository_stream.get_child_context(
+        {
+            "id": 123,
+            "name": "issues-pi",
+            "owner": {"login": "shop"},
+            "has_pull_requests": False,
+        },
+        None,
+    )
+
+    assert context["has_pull_requests"] is False
+
+
+def test_repository_child_context_defaults_pull_request_capability_to_enabled(
+    repo_list_config,  # noqa: F811
+):
+    """Preserve existing behavior when GitHub does not return the capability flag."""
+    tap = TapGitHub(config=repo_list_config)
+    repository_stream = tap.streams["repositories"]
+
+    context = repository_stream.get_child_context(
+        {
+            "id": 123,
+            "name": "tap-github",
+            "owner": {"login": "MeltanoLabs"},
+        },
+        None,
+    )
+
+    assert context["has_pull_requests"] is True
+
+
+def test_pull_requests_stream_skips_repos_with_pull_requests_disabled(
+    repo_list_config,  # noqa: F811
+):
+    """Do not call the pull requests API when repo metadata says it is disabled."""
+    tap = TapGitHub(config=repo_list_config)
+    pull_requests_stream = tap.streams["pull_requests"]
+    context = {
+        "org": "shop",
+        "repo": "issues-pi",
+        "repo_id": 123,
+        "has_pull_requests": False,
+    }
+
+    with patch.object(GitHubRestStream, "get_records") as get_records:
+        records = list(pull_requests_stream.get_records(context))
+
+    assert records == []
+    get_records.assert_not_called()
+
+
+@pytest.mark.parametrize("has_pull_requests", [True, None, "missing"])
+def test_pull_requests_stream_delegates_when_pull_request_capability_is_not_false(
+    repo_list_config,  # noqa: F811
+    has_pull_requests,
+):
+    """Fail open when the capability flag is enabled, missing, or unknown."""
+    tap = TapGitHub(config=repo_list_config)
+    pull_requests_stream = tap.streams["pull_requests"]
+    context = {
+        "org": "MeltanoLabs",
+        "repo": "tap-github",
+        "repo_id": 123,
+    }
+    if has_pull_requests != "missing":
+        context["has_pull_requests"] = has_pull_requests
+
+    with patch.object(
+        GitHubRestStream,
+        "get_records",
+        return_value=iter([{"id": 456}]),
+    ) as get_records:
+        records = list(pull_requests_stream.get_records(context))
+
+    assert records == [{"id": 456}]
+    get_records.assert_called_once_with(context)
 
 
 @pytest.mark.repo_list(["MeltanoLabs/tap-github"])

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -166,12 +166,10 @@ def test_repository_child_context_defaults_pull_request_capability_to_enabled(
     assert context["has_pull_requests"] is True
 
 
-def test_pull_requests_stream_skips_repos_with_repository_feature_exactly_false(
+def test_pull_requests_stream_skips_repos_with_pull_requests_disabled(
     repo_list_config,  # noqa: F811
-    caplog,
 ):
     """Do not call the pull requests API when repo metadata says it is disabled."""
-    caplog.set_level("INFO")
     tap = TapGitHub(config=repo_list_config)
     pull_requests_stream = tap.streams["pull_requests"]
     context = {
@@ -181,14 +179,17 @@ def test_pull_requests_stream_skips_repos_with_repository_feature_exactly_false(
         "has_pull_requests": False,
     }
 
-    with patch.object(GitHubRestStream, "get_records") as get_records:
+    with (
+        patch.object(GitHubRestStream, "get_records") as get_records,
+        patch.object(pull_requests_stream.logger, "debug") as log_debug,
+    ):
         records = list(pull_requests_stream.get_records(context))
 
     assert records == []
     get_records.assert_not_called()
-    assert "pull_requests" in caplog.text
-    assert "shop/issues-pi" in caplog.text
-    assert "has_pull_requests" in caplog.text
+    log_debug.assert_called_once_with(
+        "Repository shop/issues-pi: Pull requests not enabled, skipping API call",
+    )
 
 
 @pytest.mark.parametrize("has_pull_requests", [True, None, 0, "missing"])
@@ -242,10 +243,10 @@ def test_issues_stream_delegates_when_has_issues_is_false(
     get_records.assert_called_once_with(context)
 
 
-def test_repository_feature_gate_keeps_generic_404_retriable(
+def test_pull_requests_stream_keeps_generic_404_retriable(
     repo_list_config,  # noqa: F811
 ):
-    """Repository feature gating must not broaden tolerated GitHub errors."""
+    """Pull request gating must not broaden tolerated GitHub errors."""
     tap = TapGitHub(config=repo_list_config)
     pull_requests_stream = tap.streams["pull_requests"]
     response = Response()

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 import pytest
 from bs4 import BeautifulSoup
 from dateutil.parser import isoparse
+from requests import Response
+from singer_sdk.exceptions import RetriableAPIError
 from singer_sdk.helpers import _catalog as cat_helpers
 from singer_sdk.singerlib import Catalog
 
@@ -164,10 +166,12 @@ def test_repository_child_context_defaults_pull_request_capability_to_enabled(
     assert context["has_pull_requests"] is True
 
 
-def test_pull_requests_stream_skips_repos_with_pull_requests_disabled(
+def test_pull_requests_stream_skips_repos_with_repository_feature_exactly_false(
     repo_list_config,  # noqa: F811
+    caplog,
 ):
     """Do not call the pull requests API when repo metadata says it is disabled."""
+    caplog.set_level("INFO")
     tap = TapGitHub(config=repo_list_config)
     pull_requests_stream = tap.streams["pull_requests"]
     context = {
@@ -182,9 +186,12 @@ def test_pull_requests_stream_skips_repos_with_pull_requests_disabled(
 
     assert records == []
     get_records.assert_not_called()
+    assert "pull_requests" in caplog.text
+    assert "shop/issues-pi" in caplog.text
+    assert "has_pull_requests" in caplog.text
 
 
-@pytest.mark.parametrize("has_pull_requests", [True, None, "missing"])
+@pytest.mark.parametrize("has_pull_requests", [True, None, 0, "missing"])
 def test_pull_requests_stream_delegates_when_pull_request_capability_is_not_false(
     repo_list_config,  # noqa: F811
     has_pull_requests,
@@ -209,6 +216,47 @@ def test_pull_requests_stream_delegates_when_pull_request_capability_is_not_fals
 
     assert records == [{"id": 456}]
     get_records.assert_called_once_with(context)
+
+
+def test_issues_stream_delegates_when_has_issues_is_false(
+    repo_list_config,  # noqa: F811
+):
+    """Do not infer issues gating from repository feature metadata."""
+    tap = TapGitHub(config=repo_list_config)
+    issues_stream = tap.streams["issues"]
+    context = {
+        "org": "shop",
+        "repo": "issues-pi",
+        "repo_id": 123,
+        "has_issues": False,
+    }
+
+    with patch.object(
+        GitHubRestStream,
+        "get_records",
+        return_value=iter([{"id": 789}]),
+    ) as get_records:
+        records = list(issues_stream.get_records(context))
+
+    assert records == [{"id": 789}]
+    get_records.assert_called_once_with(context)
+
+
+def test_repository_feature_gate_keeps_generic_404_retriable(
+    repo_list_config,  # noqa: F811
+):
+    """Repository feature gating must not broaden tolerated GitHub errors."""
+    tap = TapGitHub(config=repo_list_config)
+    pull_requests_stream = tap.streams["pull_requests"]
+    response = Response()
+    response.status_code = 404
+    response.url = "https://api.github.com/repos/shop/issues-pi/pulls"
+    response.reason = "Not Found"
+    response._content = b'{"message": "Not Found"}'
+    response.headers["X-GitHub-Request-Id"] = "request-id"
+
+    with pytest.raises(RetriableAPIError, match="404 Client Error"):
+        pull_requests_stream.validate_response(response)
 
 
 @pytest.mark.repo_list(["MeltanoLabs/tap-github"])


### PR DESCRIPTION
## Summary

This PR lets the tap handle repositories that have pull requests disabled.

GitHub can return `"has_pull_requests": false` in a repository payload. For those repositories, `GET /repos/{owner}/{repo}/pulls` can return `404 Not Found` even though the repository itself is readable and other endpoints can still be extracted.

Instead of failing the sync for that case, the tap now skips pull request extraction for repositories where GitHub explicitly reports that pull requests are disabled.

## Behavior

- When `has_pull_requests` is exactly `false`, the tap skips the `/pulls` request for that repository.
- When `has_pull_requests` is `true`, missing, `null`, `0`, or otherwise unknown, behavior is unchanged: the tap still requests `/pulls` and surfaces GitHub errors normally.
- The change applies only to pull request extraction.

## Implementation

- Includes GitHub's `has_pull_requests` field in repository records.
- Carries that flag to the pull request extraction step.
- Checks the flag before requesting `/repos/{owner}/{repo}/pulls`.

## What this does not change

- It does not add broad `404` or `403` tolerance.
- It does not change issue extraction or infer pull request availability from `has_issues`.
- It does not change discussion extraction.

## Validation

```text
LOGLEVEL=WARNING uv run pytest tests/test_tap.py -k 'pull_request_capability or pull_requests_stream or issues_stream'
# 9 passed, 8 deselected

uv run ruff check tap_github/repository_streams.py tests/test_tap.py
# All checks passed

uv run mypy tap_github
# Success: no issues found in 12 source files

uv run ty check tap_github
# All checks passed

git diff --check
# passed
```
<!-- github-gate:idempotency=tap-github-pr571-body-proposal-only -->