### PR TITLE
fix: coerce ProjectItems field id to string for schema validation

### DIFF
--- a/tap_github/organization_streams.py
+++ b/tap_github/organization_streams.py
@@ -874,7 +874,10 @@ class ProjectItemsStream(GitHubGraphqlStream):
                 # Copy all the values
                 for key in ["node_id", "id", "created_at", "updated_at"]:
                     if key in field_value_data:
-                        entry[key] = field_value_data[key]
+                        value = field_value_data[key]
+                        if key == "id" and value is not None:
+                            value = str(value)
+                        entry[key] = value
 
                 # Copy creator if present
                 if "creator" in field_value_data:


### PR DESCRIPTION
## Summary

- Coerce GraphQL `databaseId` to `str` when copying field values in `ProjectItemsStream.post_process`
- Fixes jsonschema validation failures for `title.id`, `status.id`, and `field_values[].id`, which are declared `string|null` but were receiving integer values from GraphQL
- Minimal change: only `id` is coerced when present; other copied keys are unchanged

Fixes #514

## Test plan

- [x] `uv run mypy tap_github` passes
- [ ] `uv run pytest` (not run in this PR; change is localized to post-processing logic)